### PR TITLE
Fix async control flow

### DIFF
--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/avro-kafkajs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A wrapper around Kafkajs to transparently use Schema Registry for producing and consuming messages with avro schemas.",

--- a/packages/avro-kafkajs/src/avro.ts
+++ b/packages/avro-kafkajs/src/avro.ts
@@ -66,7 +66,7 @@ export const toAvroEachMessage = <T = unknown>(
 ): ((payload: EachMessagePayload) => Promise<void>) => {
   return async payload => {
     const { type, value } = await schemaRegistry.decodeWithType<T>(payload.message.value);
-    eachMessage({ ...payload, message: { ...payload.message, value, schema: type.schema() } });
+    return eachMessage({ ...payload, message: { ...payload.message, value, schema: type.schema() } });
   };
 };
 
@@ -82,7 +82,7 @@ export const toAvroEachBatch = <T = unknown>(
       messages.push({ ...message, value, schema: type.schema() });
     }
     avroPayload.batch.messages = messages;
-    eachBatch(avroPayload);
+    return eachBatch(avroPayload);
   };
 };
 

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",
@@ -39,7 +39,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.1.0",
+    "@ovotech/avro-kafkajs": "^0.1.2",
     "kafkajs": "^1.11.0"
   }
 }


### PR DESCRIPTION
 This prevents `UnhandledPromiseRejectionWarning` events when the provided `eachBatch` or `eachMessage` throws.

With this change KafkaJS retry mechanism kicks in (up to 5 times by default then bail), and the error is logged (also by kafkaJS).