### PR TITLE
Expose autoCommit and other missing config in types

### DIFF
--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/avro-kafkajs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A wrapper around Kafkajs to transparently use Schema Registry for producing and consuming messages with avro schemas.",

--- a/packages/avro-kafkajs/src/types.ts
+++ b/packages/avro-kafkajs/src/types.ts
@@ -1,4 +1,5 @@
 import {
+  Consumer,
   EachMessagePayload,
   Batch,
   EachBatchPayload,
@@ -9,6 +10,8 @@ import {
   KafkaMessage,
 } from 'kafkajs';
 import { Schema } from 'avsc';
+
+type Arg1<T> = T extends (arg1: infer U) => any ? U : never;
 
 export interface AvroEachMessagePayload<T = unknown> extends Omit<EachMessagePayload, 'message'> {
   message: AvroKafkaMessage<T>;
@@ -48,14 +51,12 @@ export interface AvroProducerBatch extends Omit<ProducerBatch, 'topicMessages'> 
   topicMessages: AvroTopicMessages[];
 }
 
-export interface AvroConsumerRun<T = unknown> {
-  autoCommit?: boolean;
-  autoCommitInterval?: number | null;
-  autoCommitThreshold?: number | null;
-  eachBatchAutoResolve?: boolean;
-  partitionsConsumedConcurrently?: number;
+export type AvroConsumerRun<T = unknown> = Omit<
+  Arg1<Consumer['run']>,
+  'eachBatch' | 'eachMessage'
+> & {
   eachBatch?: (payload: AvroEachBatchPayload<T>) => Promise<void>;
   eachMessage?: (payload: AvroEachMessagePayload<T>) => Promise<void>;
-}
+};
 
 export type TopicsAlias = { [key: string]: string };

--- a/packages/avro-kafkajs/src/types.ts
+++ b/packages/avro-kafkajs/src/types.ts
@@ -1,5 +1,4 @@
 import {
-  Consumer,
   EachMessagePayload,
   Batch,
   EachBatchPayload,
@@ -10,8 +9,6 @@ import {
   KafkaMessage,
 } from 'kafkajs';
 import { Schema } from 'avsc';
-
-type Arg1<T> = T extends (arg1: infer U) => any ? U : never;
 
 export interface AvroEachMessagePayload<T = unknown> extends Omit<EachMessagePayload, 'message'> {
   message: AvroKafkaMessage<T>;
@@ -51,12 +48,14 @@ export interface AvroProducerBatch extends Omit<ProducerBatch, 'topicMessages'> 
   topicMessages: AvroTopicMessages[];
 }
 
-export type AvroConsumerRun<T = unknown> = Omit<
-  Arg1<Consumer['run']>,
-  'eachBatch' | 'eachMessage'
-> & {
+export interface AvroConsumerRun<T = unknown> {
+  autoCommit?: boolean;
+  autoCommitInterval?: number | null;
+  autoCommitThreshold?: number | null;
+  eachBatchAutoResolve?: boolean;
+  partitionsConsumedConcurrently?: number;
   eachBatch?: (payload: AvroEachBatchPayload<T>) => Promise<void>;
   eachMessage?: (payload: AvroEachMessagePayload<T>) => Promise<void>;
-};
+}
 
 export type TopicsAlias = { [key: string]: string };

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -39,7 +39,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.1.2",
+    "@ovotech/avro-kafkajs": "^0.1.3",
     "kafkajs": "^1.11.0"
   }
 }

--- a/packages/castle/src/types.ts
+++ b/packages/castle/src/types.ts
@@ -1,4 +1,3 @@
-import { Consumer } from 'kafkajs';
 import {
   AvroProducer,
   AvroEachMessagePayload,
@@ -11,8 +10,6 @@ import {
   TopicsAlias,
 } from '@ovotech/avro-kafkajs';
 import { ConsumerConfig, KafkaConfig, ProducerConfig, RecordMetadata, AdminConfig } from 'kafkajs';
-
-type Arg1<T> = T extends (arg1: infer U) => any ? U : never;
 
 export interface CastleEachMessagePayload<T = unknown> extends AvroEachMessagePayload<T> {
   producer: AvroProducer;
@@ -31,12 +28,12 @@ export type Middleware<TProvide extends object = {}, TRequire extends object = {
 ) => Resolver<TRequire & TInherit>;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export type CastleConsumerConfig<T = any> = ConsumerConfig &
-  Omit<AvroConsumerRun, 'eachBatch' | 'eachMessage'> &
-  Arg1<Consumer['subscribe']> & {
-    eachBatch?: (ctx: CastleEachBatchPayload<T>) => Promise<void>;
-    eachMessage?: (ctx: CastleEachMessagePayload<T>) => Promise<void>;
-  };
+export type CastleConsumerConfig<T = any> = ConsumerConfig & Omit<AvroConsumerRun, 'eachBatch'|'eachMessage'> & {
+  topic: string | RegExp;
+  fromBeginning?: boolean;
+  eachBatch?: (ctx: CastleEachBatchPayload<T>) => Promise<void>;
+  eachMessage?: (ctx: CastleEachMessagePayload<T>) => Promise<void>;
+}
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export interface CastleConsumer<T = any> {

--- a/packages/castle/src/types.ts
+++ b/packages/castle/src/types.ts
@@ -1,3 +1,4 @@
+import { Consumer } from 'kafkajs';
 import {
   AvroProducer,
   AvroEachMessagePayload,
@@ -10,6 +11,8 @@ import {
   TopicsAlias,
 } from '@ovotech/avro-kafkajs';
 import { ConsumerConfig, KafkaConfig, ProducerConfig, RecordMetadata, AdminConfig } from 'kafkajs';
+
+type Arg1<T> = T extends (arg1: infer U) => any ? U : never;
 
 export interface CastleEachMessagePayload<T = unknown> extends AvroEachMessagePayload<T> {
   producer: AvroProducer;
@@ -28,12 +31,12 @@ export type Middleware<TProvide extends object = {}, TRequire extends object = {
 ) => Resolver<TRequire & TInherit>;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export type CastleConsumerConfig<T = any> = ConsumerConfig & Omit<AvroConsumerRun, 'eachBatch'|'eachMessage'> & {
-  topic: string | RegExp;
-  fromBeginning?: boolean;
-  eachBatch?: (ctx: CastleEachBatchPayload<T>) => Promise<void>;
-  eachMessage?: (ctx: CastleEachMessagePayload<T>) => Promise<void>;
-}
+export type CastleConsumerConfig<T = any> = ConsumerConfig &
+  Omit<AvroConsumerRun, 'eachBatch' | 'eachMessage'> &
+  Arg1<Consumer['subscribe']> & {
+    eachBatch?: (ctx: CastleEachBatchPayload<T>) => Promise<void>;
+    eachMessage?: (ctx: CastleEachMessagePayload<T>) => Promise<void>;
+  };
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export interface CastleConsumer<T = any> {

--- a/packages/castle/src/types.ts
+++ b/packages/castle/src/types.ts
@@ -4,6 +4,7 @@ import {
   AvroEachBatchPayload,
   SchemaRegistryConfig,
   AvroConsumer,
+  AvroConsumerRun,
   AvroMessage,
   AvroKafka,
   TopicsAlias,
@@ -27,10 +28,9 @@ export type Middleware<TProvide extends object = {}, TRequire extends object = {
 ) => Resolver<TRequire & TInherit>;
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export interface CastleConsumerConfig<T = any> extends ConsumerConfig {
+export type CastleConsumerConfig<T = any> = ConsumerConfig & Omit<AvroConsumerRun, 'eachBatch'|'eachMessage'> & {
   topic: string | RegExp;
   fromBeginning?: boolean;
-  partitionsConsumedConcurrently?: number;
   eachBatch?: (ctx: CastleEachBatchPayload<T>) => Promise<void>;
   eachMessage?: (ctx: CastleEachMessagePayload<T>) => Promise<void>;
 }

--- a/packages/castle/src/types.ts
+++ b/packages/castle/src/types.ts
@@ -27,13 +27,20 @@ export type Middleware<TProvide extends object = {}, TRequire extends object = {
   next: Resolver<TProvide & TRequire & TInherit>,
 ) => Resolver<TRequire & TInherit>;
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export type CastleConsumerConfig<T = any> = ConsumerConfig & Omit<AvroConsumerRun, 'eachBatch'|'eachMessage'> & {
+export type CastleTopicSubscribe<T = unknown> = {
   topic: string | RegExp;
   fromBeginning?: boolean;
   eachBatch?: (ctx: CastleEachBatchPayload<T>) => Promise<void>;
   eachMessage?: (ctx: CastleEachMessagePayload<T>) => Promise<void>;
-}
+};
+
+export type CastleConsumerRun<T = unknown> = Omit<AvroConsumerRun<T>, 'eachBatch' | 'eachMessage'>;
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export interface CastleConsumerConfig<T = any>
+  extends ConsumerConfig,
+    CastleConsumerRun<T>,
+    CastleTopicSubscribe<T> {}
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export interface CastleConsumer<T = any> {


### PR DESCRIPTION
This is a draft as the version updates would require #2 to be merged first.

I was particularly looking for disabling `autoCommit`.

~I then learned about the `Arg1` trick and realised there is no need to re-define those types.
It hinders readability a bit though, so I'm not opposed to reverting to the first commit on this PR.~ TS compiler was not happy, and I don't really understand why. Problem for another time.

