### PR TITLE
Fix Blaise dependency

### DIFF
--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -49,13 +49,13 @@
     "eslint-config-prettier": "^6.9.0",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",
-    "ts-essentials": "^4.0.0",
     "ts-jest": "^24.3.0",
     "typescript": "^3.7.4"
   },
   "dependencies": {
     "@ovotech/avro-mock-generator": "^1.1.3",
-    "lodash.merge": "^4.6.2"
+    "lodash.merge": "^4.6.2",
+    "ts-essentials": "^4.0.0"
   },
   "peerDependencies": {
     "@ovotech/castle": ">=0.3"

--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/blaise",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An API to generate mock payloads for @ovotech/castle using @ovotech/avro-mock-generator",
   "keywords": [
     "castle",


### PR DESCRIPTION
We have a library that rewraps Blaise (to set our default generators), but it's failing to build because `ts-essentials` are missing from the types :cry: 
