### PR TITLE
Upgrade kafkajs to avoid duplicating type definition

### DIFF
--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/avro-kafkajs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A wrapper around Kafkajs to transparently use Schema Registry for producing and consuming messages with avro schemas.",

--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -17,7 +17,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.7.0",
     "jest": "^24.9.0",
-    "kafkajs": "^1.11.0",
+    "kafkajs": "^1.12.0",
     "prettier": "^1.19.1",
     "ts-jest": "^24.2.0",
     "ts-node": "^8.5.4",
@@ -37,7 +37,7 @@
     "preset": "../../jest.json"
   },
   "peerDependencies": {
-    "kafkajs": "^1.11.0"
+    "kafkajs": "^1.12.0"
   },
   "dependencies": {
     "@ovotech/schema-registry-api": "^1.0.5",

--- a/packages/avro-kafkajs/src/AvroConsumer.ts
+++ b/packages/avro-kafkajs/src/AvroConsumer.ts
@@ -6,6 +6,7 @@ import {
   TopicPartitions,
   ConsumerEvents,
   ValueOf,
+  RemoveInstrumentationEventListener,
 } from 'kafkajs';
 import { AvroConsumerRun, TopicsAlias } from './types';
 import { toAvroEachMessage, toAvroEachBatch, resolveTopic } from './avro';
@@ -71,7 +72,10 @@ export class AvroConsumer {
     return this.consumer.resume(topics.map(topic => resolveTopic(topic, this.topicsAlias)));
   }
 
-  public on(eventName: ValueOf<ConsumerEvents>, listener: (...args: unknown[]) => void): void {
+  public on(
+    eventName: ValueOf<ConsumerEvents>,
+    listener: (...args: unknown[]) => void,
+  ): RemoveInstrumentationEventListener<typeof eventName> {
     return this.consumer.on(eventName, listener);
   }
 }

--- a/packages/avro-kafkajs/src/AvroProducer.ts
+++ b/packages/avro-kafkajs/src/AvroProducer.ts
@@ -1,5 +1,12 @@
 import { SchemaRegistry } from './SchemaRegistry';
-import { Producer, Logger, RecordMetadata, ProducerEvents, ValueOf } from 'kafkajs';
+import {
+  Producer,
+  Logger,
+  RecordMetadata,
+  ProducerEvents,
+  ValueOf,
+  RemoveInstrumentationEventListener,
+} from 'kafkajs';
 import { AvroProducerRecord, AvroProducerBatch, TopicsAlias } from './types';
 import { AvroTransaction } from './AvroTransaction';
 import { toProducerRecord, toProducerBatch, resolveTopic } from './avro';
@@ -46,7 +53,10 @@ export class AvroProducer {
     );
   }
 
-  public on(eventName: ValueOf<ProducerEvents>, listener: (...args: unknown[]) => void): void {
+  public on(
+    eventName: ValueOf<ProducerEvents>,
+    listener: (...args: unknown[]) => void,
+  ): RemoveInstrumentationEventListener<typeof eventName> {
     return this.producer.on(eventName, listener);
   }
 }

--- a/packages/avro-kafkajs/src/types.ts
+++ b/packages/avro-kafkajs/src/types.ts
@@ -7,6 +7,7 @@ import {
   TopicMessages,
   ProducerBatch,
   KafkaMessage,
+  ConsumerRunConfig,
 } from 'kafkajs';
 import { Schema } from 'avsc';
 
@@ -48,12 +49,8 @@ export interface AvroProducerBatch extends Omit<ProducerBatch, 'topicMessages'> 
   topicMessages: AvroTopicMessages[];
 }
 
-export interface AvroConsumerRun<T = unknown> {
-  autoCommit?: boolean;
-  autoCommitInterval?: number | null;
-  autoCommitThreshold?: number | null;
-  eachBatchAutoResolve?: boolean;
-  partitionsConsumedConcurrently?: number;
+export interface AvroConsumerRun<T = unknown>
+  extends Omit<ConsumerRunConfig, 'eachBatch' | 'eachMessage'> {
   eachBatch?: (payload: AvroEachBatchPayload<T>) => Promise<void>;
   eachMessage?: (payload: AvroEachMessagePayload<T>) => Promise<void>;
 }

--- a/packages/castle-cli/package.json
+++ b/packages/castle-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle-cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka avro cli",
@@ -38,11 +38,11 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.1.0",
+    "@ovotech/avro-kafkajs": "^0.1.4",
     "ansi-regex": "^5.0.0",
     "chalk": "^3.0.0",
     "commander": "^4.0.1",
-    "kafkajs": "^1.11.0",
+    "kafkajs": "^1.12.0",
     "long": "^4.0.0",
     "runtypes": "^4.0.3",
     "uuid": "^3.3.3"

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "@ovotech/avro-kafkajs": "^0.1.3",
-    "kafkajs": "^1.11.0"
+    "kafkajs": "^1.12.0"
   }
 }

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",
@@ -39,7 +39,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.1.3",
+    "@ovotech/avro-kafkajs": "^0.1.4",
     "kafkajs": "^1.12.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,6 +4440,13 @@ kafkajs@^1.11.0:
   dependencies:
     long "^4.0.0"
 
+kafkajs@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.12.0.tgz#50ad336baee95f3324af8ae8df6fadc96e07c613"
+  integrity sha512-Izkd9iFRgeeKaHEgVpGQH08ygzCbHSxTbnu8W3G3uiNaVjGibUTmTwjv1Qf2M8NORXcPfzwVyg6bBlVj4SKr9g==
+  dependencies:
+    long "^4.0.0"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4433,13 +4433,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-kafkajs@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.11.0.tgz#d9599b02ada63ec7c63948b6ddfe0bc3a02c6dcc"
-  integrity sha512-dLRCcFIBygZucR+e8U2ZqH2wgMrAu114K0szUyUseJoeOii3cG5bHZPIdqKecXxI6begPVCfGS3R0nJY4zHW2A==
-  dependencies:
-    long "^4.0.0"
-
 kafkajs@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.12.0.tgz#50ad336baee95f3324af8ae8df6fadc96e07c613"


### PR DESCRIPTION
This cleans up the duplication brought by #3 .

~I didn't update package version as the signatures are unchanged, it doesn't feel like we need to republish?~

Signature changed happened for the definition of the event listener remover.