### PR TITLE
Update TS types to be more strict

### DIFF
--- a/packages/castle/src/castle.ts
+++ b/packages/castle/src/castle.ts
@@ -14,21 +14,33 @@ import {
   CastleSender,
   CastleEachMessagePayload,
   CastleEachBatchPayload,
+  FinalCastleConsumerConfig,
 } from './types';
-import { eachSizedBatch } from './each-sized-batch';
+import { withEachSizedBatch } from './each-sized-batch';
 
-const withProducer = (producer: AvroProducer) => ({
-  eachBatch,
-  eachMessage,
-  ...rest
-}: CastleConsumerConfig): AvroConsumerRun => ({
-  ...rest,
-  eachBatch: eachBatch ? payload => eachBatch({ ...payload, producer }) : undefined,
-  eachMessage: eachMessage ? payload => eachMessage({ ...payload, producer }) : undefined,
-});
+const withProducer = <T = unknown>(producer: AvroProducer) => (
+  config: FinalCastleConsumerConfig<T>,
+): AvroConsumerRun<T> => {
+  if ('eachBatch' in config) {
+    return { ...config, eachBatch: payload => config.eachBatch({ ...payload, producer }) };
+  } else {
+    return { ...config, eachMessage: payload => config.eachMessage({ ...payload, producer }) };
+  }
+};
 
 export const produce = <T>(config: Omit<AvroProducerRecord<T>, 'messages'>): CastleSender<T> => {
   return (producer, messages) => producer.send<T>({ ...config, messages });
+};
+
+export const toFinalCastleConsumerConfig = (
+  config: CastleConsumerConfig,
+): FinalCastleConsumerConfig => {
+  if ('eachSizedBatch' in config) {
+    const { eachSizedBatch, maxBatchSize, ...rest } = config;
+    return { ...rest, eachBatch: withEachSizedBatch(eachSizedBatch, maxBatchSize) };
+  } else {
+    return config;
+  }
 };
 
 export const consumeEachMessage = <T, TContext extends object = {}>(
@@ -44,16 +56,8 @@ export const createCastle = (config: CastleConfig): Castle => {
   const kafka = new AvroKafka(schemaRegistry, new Kafka(config.kafka), config.topicsAlias);
   const producer = kafka.producer(config.producer);
   const consumers: CastleConsumer[] = config.consumers.map(config => {
-    let consumerConfig: CastleConsumerConfig;
-    if (config.eachSizedBatch) {
-      consumerConfig = eachSizedBatch(config);
-    } else {
-      consumerConfig = config;
-    }
-    return {
-      instance: kafka.consumer(consumerConfig),
-      config: consumerConfig,
-    };
+    const finalConfig = toFinalCastleConsumerConfig(config);
+    return { instance: kafka.consumer(finalConfig), config: finalConfig };
   });
 
   const services = [producer, ...consumers.map(consumer => consumer.instance)];

--- a/packages/castle/src/describe.ts
+++ b/packages/castle/src/describe.ts
@@ -23,19 +23,13 @@ export const describeTopicAliases = (topicAlias: TopicsAlias): string | undefine
 export const describeCastleConsumers = (castleConfigs: CastleConsumer[]): string | undefined => {
   const titles = ['Topic', 'Original Topic', 'Type', 'Group', 'Concurrency', 'From Beginning'];
   const descriptions = castleConfigs.map(({ config, instance }) => {
-    const {
-      topic,
-      partitionsConsumedConcurrently,
-      eachBatch,
-      eachMessage,
-      groupId,
-      fromBeginning,
-    } = config;
+    const { topic, partitionsConsumedConcurrently, groupId, fromBeginning } = config;
+    const message = 'eachBatch' in config ? 'Batch' : 'Message';
 
     return [
       String(topic),
       typeof topic === 'string' && instance.topicsAlias[topic] ? instance.topicsAlias[topic] : '-',
-      eachBatch ? 'Batch' : eachMessage ? 'Message' : '-',
+      message,
       groupId,
       partitionsConsumedConcurrently === undefined ? '-' : String(partitionsConsumedConcurrently),
       fromBeginning ? 'Yes' : '-',

--- a/packages/castle/src/each-sized-batch.ts
+++ b/packages/castle/src/each-sized-batch.ts
@@ -1,61 +1,49 @@
-import { CastleConsumerConfig, CastleEachBatchPayload } from './types';
+import { CastleEachBatchPayload } from './types';
 import chunk = require('lodash.chunk');
 
-export const eachSizedBatch = <T extends any>(
-  consumerConf: CastleConsumerConfig<T>,
-): CastleConsumerConfig<T> => {
-  const { maxBatchSize, eachSizedBatch, ...consumer } = consumerConf;
-  if (!maxBatchSize) {
-    return {
-      ...consumer,
-      eachBatch: eachSizedBatch,
-    };
+export const withEachSizedBatch = <T extends unknown>(
+  eachSizedBatch: (ctx: CastleEachBatchPayload<T>) => Promise<void>,
+  maxBatchSize: number,
+): ((ctx: CastleEachBatchPayload<T>) => Promise<void>) => async (
+  payload: CastleEachBatchPayload<T>,
+) => {
+  const {
+    batch: { messages },
+    isRunning,
+    isStale,
+    commitOffsetsIfNecessary,
+    heartbeat,
+    resolveOffset,
+  } = payload;
+
+  for (const msgBatch of chunk(messages, maxBatchSize)) {
+    /* avoid processing if the whole batch has been invalidated
+     * (can happen with rebalances for example)
+     */
+    if (!isRunning() || isStale()) {
+      break;
+    }
+    await eachSizedBatch({
+      ...payload,
+      batch: {
+        ...payload.batch,
+        messages: msgBatch,
+      },
+    });
+    /* Tell the broker we are still alive to avoid a rebalance if processing
+     * the batch takes a long time
+     */
+    await heartbeat();
+    const higherOffset = msgBatch
+      .map(({ offset }) => +offset)
+      .sort((a, b) => a - b)
+      .pop() as number;
+    /* Mark offset up to the last one as resolved
+     */
+    resolveOffset(higherOffset.toString());
+    /* Commit offset of any resolved messages
+     * if autoCommitThreshold or autoCommitInterval has been reached
+     */
+    await commitOffsetsIfNecessary();
   }
-
-  return {
-    ...consumer,
-    eachBatch: async (payload: CastleEachBatchPayload<T>) => {
-      const {
-        batch: { messages },
-        isRunning,
-        isStale,
-        commitOffsetsIfNecessary,
-        heartbeat,
-        resolveOffset,
-      } = payload;
-
-      for (const msgBatch of chunk(messages, maxBatchSize)) {
-        /* avoid processing if the whole batch has been invalidated
-         * (can happen with rebalances for example)
-         */
-        if (!isRunning() || isStale()) {
-          break;
-        }
-
-        await eachSizedBatch!({
-          ...payload,
-          batch: {
-            ...payload.batch,
-            messages: msgBatch,
-          },
-        });
-
-        /* Tell the broker we are still alive to avoid a rebalance if processing
-         * the batch takes a long time
-         */
-        await heartbeat();
-        const higherOffset = msgBatch
-          .map(({ offset }: { offset: string }) => +offset)
-          .sort((a: number, b: number) => a - b)
-          .pop()!;
-        /* Mark offset up to the last one as resolved
-         */
-        resolveOffset(higherOffset.toString());
-        /* Commit offset of any resolved messages
-         * if autoCommitThreshold or autoCommitInterval has been reached
-         */
-        await commitOffsetsIfNecessary();
-      }
-    },
-  };
 };

--- a/packages/castle/test/integration.spec.ts
+++ b/packages/castle/test/integration.spec.ts
@@ -58,7 +58,7 @@ const eachEvent2 = consumeEachBatch<Event2, LoggingContext>(async ({ batch, logg
   }
 });
 
-const log: Array<[string, string, any]> = [];
+const log: Array<[string, string, unknown]> = [];
 const myLogger: Logger = {
   log: (level, message, metadata) => log.push([level, message, metadata]),
 };
@@ -66,6 +66,7 @@ const logging = createLogging(myLogger);
 const logCreator = toLogCreator(myLogger);
 
 const batchSizer = jest.fn();
+let admin: Admin;
 const castle = createCastle({
   schemaRegistry: { uri: 'http://localhost:8081' },
   kafka: { brokers: ['localhost:29092'], logCreator },
@@ -93,7 +94,6 @@ const castle = createCastle({
     },
   ],
 });
-let admin: Admin;
 
 describe('Integration', () => {
   beforeEach(async () => {


### PR DESCRIPTION
In order for this to work, I've made some internal "Final" castle types that stuff gets converted to. 
TS makes sure we will have it working without exceptions, though it at this time is not smart enough to warn the user of castle that he has "eachBatch" and "eachSizedBatch" together.
As the types themselves express our intent exactly, I think that's fine to be honest. I think they will fix this in due time.

Also has room for adding additional "specialised" batch approaches if we need them, that would get converted to the "final" kafkajs ones

What do you think of this approach?

(This is a PR against your #7 @nicolaslt)