### PR TITLE
Extract logical types from ovotech/bit-node-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ castle --config uat topic consume my-topic-full-name
 
 Using it without a specified config would connect to the default local kafka server.
 
+## Castle also holds a collection of avro logical types, separate into descrete packages
+
+- [@ovotech/avro-timestamp-millis](packages/avro-timestamp-millis) - Date stored as the number of milliseconds since epoch
+- [@ovotech/avro-epoch-days](packages/avro-epoch-days) - Date stored as the number of days since epoch
+- [@ovotech/avro-decimal](packages/avro-decimal) - Decimal object value as raw bytes
+
 ## Running the tests
 
 You can run the tests with:

--- a/packages/avro-decimal/.npmignore
+++ b/packages/avro-decimal/.npmignore
@@ -1,0 +1,7 @@
+.*
+test/
+src/
+examples/
+coverage/
+tsconfig.json
+yarn-error.log

--- a/packages/avro-decimal/LICENSE
+++ b/packages/avro-decimal/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019-2020 OVO Energy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/avro-decimal/README.md
+++ b/packages/avro-decimal/README.md
@@ -8,7 +8,7 @@ A Logical type for representing a decimal object value as raw bytes
 yarn add @ovotech/avro-decimal
 ```
 
-And then you can use `AvroDecimal` for a logicalType of a feild.
+And then you can use `AvroDecimal` for a logicalType of a field.
 
 > [examples/simple.ts](examples/simple.ts)
 

--- a/packages/avro-decimal/README.md
+++ b/packages/avro-decimal/README.md
@@ -1,0 +1,65 @@
+# Avro Decimal
+
+A Logical type for representing a decimal object value as raw bytes
+
+### Using
+
+```bash
+yarn add @ovotech/avro-decimal
+```
+
+And then you can use `AvroDecimal` for a logicalType of a feild.
+
+> [examples/simple.ts](examples/simple.ts)
+
+```typescript
+import { Type, Schema } from 'avsc';
+import { AvroDecimal } from '@ovotech/avro-decimal';
+import { Decimal } from 'decimal.js';
+
+const decimalSchema: Schema = {
+  type: 'bytes',
+  logicalType: 'decimal',
+  precision: 16,
+  scale: 8,
+};
+
+export const DecimalType = Type.forSchema(decimalSchema, {
+  logicalTypes: { decimal: AvroDecimal },
+});
+
+const encoded = DecimalType.toBuffer(new Decimal('100.01'));
+const decoded = DecimalType.fromBuffer(encoded);
+
+console.log(decoded);
+```
+
+## Running the tests
+
+Then you can run the tests with:
+
+```bash
+yarn test
+```
+
+### Coding style (linting, etc) tests
+
+Style is maintained with prettier and tslint
+
+```
+yarn lint
+```
+
+## Deployment
+
+Deployment is preferment by lerna automatically on merge / push to master, but you'll need to bump the package version numbers yourself. Only updated packages with newer versions will be pushed to the npm registry.
+
+## Contributing
+
+Have a bug? File an issue with a simple example that reproduces this so we can take a look & confirm.
+
+Want to make a change? Submit a PR, explain why it's useful, and make sure you've updated the docs (this file) and the tests (see [test folder](test)).
+
+## License
+
+This project is licensed under Apache 2 - see the [LICENSE](LICENSE) file for details

--- a/packages/avro-decimal/examples/simple.ts
+++ b/packages/avro-decimal/examples/simple.ts
@@ -1,0 +1,19 @@
+import { Type, Schema } from 'avsc';
+import { AvroDecimal } from '@ovotech/avro-decimal';
+import { Decimal } from 'decimal.js';
+
+const decimalSchema: Schema = {
+  type: 'bytes',
+  logicalType: 'decimal',
+  precision: 16,
+  scale: 8,
+};
+
+export const DecimalType = Type.forSchema(decimalSchema, {
+  logicalTypes: { decimal: AvroDecimal },
+});
+
+const encoded = DecimalType.toBuffer(new Decimal('100.01'));
+const decoded = DecimalType.fromBuffer(encoded);
+
+console.log(decoded);

--- a/packages/avro-decimal/package.json
+++ b/packages/avro-decimal/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ovotech/avro-decimal",
+  "description": "A logical type representing Decimal as binary bytes",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "author": "Ivan Kerin <ikerin@gmail.com>",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest --runInBand",
+    "lint:prettier": "prettier --list-different {src,test}/**/*.ts",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint": "yarn lint:prettier && yarn lint:eslint",
+    "build": "tsc --outDir dist --declaration",
+    "build:docs": "build-docs README.md"
+  },
+  "devDependencies": {
+    "avsc": "^5.4.18",
+    "eslint-config-prettier": "^6.10.0",
+    "jest": "^25.1.0",
+    "prettier": "^1.19.1",
+    "ts-jest": "^25.2.1",
+    "ts-node": "^8.6.2"
+  },
+  "peerDependencies": {
+    "avsc": "^5.4.18"
+  },
+  "dependencies": {
+    "decimal.js": "^10.2.0",
+    "int64-buffer": "^0.99.1007"
+  },
+  "jest": {
+    "preset": "../../jest.json"
+  }
+}

--- a/packages/avro-decimal/src/index.ts
+++ b/packages/avro-decimal/src/index.ts
@@ -1,0 +1,81 @@
+import { Type, Schema, types } from 'avsc';
+import { Decimal } from 'decimal.js';
+import { Int64BE } from 'int64-buffer';
+
+export function decimalToBuffer(val: Decimal, scale: number): Buffer {
+  const scaled = val.mul(10 ** scale);
+  const value = new Int64BE(scaled.trunc().toString());
+  return value.toBuffer();
+}
+
+export function to64Bit(buf: Buffer): Buffer {
+  const isNegatve = buf[0] & 0x80;
+  const toFill = 8 - buf.length;
+
+  const bufferElements = Array.prototype.slice.call(buf, 0);
+
+  return Buffer.from([
+    ...[...new Array(toFill)].map(() => (isNegatve ? 0xff : 0x00)),
+    ...bufferElements,
+  ]);
+}
+
+export function bufferToDecimal(buf: Buffer, scale: number): Decimal {
+  const unscaled = new Int64BE(to64Bit(buf));
+  return new Decimal(unscaled.toString()).div(10 ** scale);
+}
+
+export interface SchemaOptions {
+  precision: number;
+  scale: number;
+}
+
+export class AvroDecimal extends types.LogicalType {
+  public precision: number;
+  public scale: number;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(schema: any, opts?: unknown) {
+    super(schema, opts);
+    this.precision = schema.precision;
+    this.scale = schema.scale;
+  }
+
+  public _export(attrs: Schema & SchemaOptions): void {
+    attrs.precision = this.precision;
+    attrs.scale = this.scale;
+  }
+
+  public _resolve(type: Type & SchemaOptions): (<T>(x: T) => T) | undefined {
+    if (
+      type instanceof AvroDecimal &&
+      Type.isType(type, 'logical:decimal') &&
+      type.precision === this.precision &&
+      type.scale === this.scale
+    ) {
+      return x => x;
+    } else {
+      return undefined;
+    }
+  }
+
+  public _fromValue(buf: unknown): Decimal {
+    if (!(buf instanceof Buffer)) {
+      throw new Error('expecting underlying Buffer type');
+    }
+
+    if (buf.length > 8) {
+      throw new Error('buffers with more than 64bits are not supported');
+    }
+
+    return bufferToDecimal(buf, this.scale);
+  }
+
+  public _toValue(val: unknown): Buffer {
+    if (!(val instanceof Decimal)) {
+      throw new Error('expecting Decimal type');
+    }
+
+    return decimalToBuffer(val, this.scale);
+  }
+}

--- a/packages/avro-decimal/test/integration.spec.ts
+++ b/packages/avro-decimal/test/integration.spec.ts
@@ -1,0 +1,84 @@
+import { Type } from 'avsc';
+import { Decimal } from 'decimal.js';
+import { bufferToDecimal, decimalToBuffer, to64Bit, AvroDecimal } from '../src';
+
+export const decimalSchema = Type.forSchema(
+  {
+    type: 'bytes',
+    logicalType: 'decimal',
+    precision: 16,
+    scale: 8,
+  },
+  {
+    logicalTypes: { decimal: AvroDecimal },
+  },
+);
+
+describe('DecimalSchema', () => {
+  it('can serialise/deserialise a decimal', () => {
+    const d = new Decimal('100.01');
+    expect(d).toEqual(decimalSchema.fromBuffer(decimalSchema.toBuffer(d)));
+  });
+
+  it('truncates decimals with greater scale', () => {
+    const d = new Decimal('99999999.999999999');
+    expect(new Decimal('99999999.99999999')).toEqual(
+      decimalSchema.fromBuffer(decimalSchema.toBuffer(d)),
+    );
+  });
+});
+
+describe('to64Bit', () => {
+  it('correctly converts the buffer for a positive number to a 64bit one', () => {
+    // buffer for number 1
+    const input = Buffer.from([0x01]);
+
+    expect(
+      to64Bit(input).equals(Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01])),
+    ).toBe(true);
+  });
+
+  it('correctly converts the buffer for a negative number to a 64bit one', () => {
+    // buffer for number -1
+    const input = Buffer.from([0xff]);
+
+    expect(
+      to64Bit(input).equals(Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])),
+    ).toBe(true);
+  });
+});
+
+describe('bufferToDecimal', () => {
+  it('converts any <= 8byte buffer to a decimal', () => {
+    const testOneBuffers = [
+      Buffer.from([0x01]),
+      Buffer.from([0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+    ];
+
+    testOneBuffers.forEach(b => {
+      expect(bufferToDecimal(b, 0).equals('1')).toBe(true);
+      expect(bufferToDecimal(b, 4).equals('0.0001')).toBe(true);
+    });
+  });
+});
+
+describe('decimalToBuffer', () => {
+  it('converts any decimal to an 8byte buffer', () => {
+    expect(
+      decimalToBuffer(new Decimal('1'), 0).equals(
+        Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+      ),
+    ).toBe(true);
+    expect(
+      decimalToBuffer(new Decimal('0.0001'), 4).equals(
+        Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/avro-decimal/tsconfig.json
+++ b/packages/avro-decimal/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/avro-epoch-days/.npmignore
+++ b/packages/avro-epoch-days/.npmignore
@@ -1,0 +1,7 @@
+.*
+test/
+src/
+examples/
+coverage/
+tsconfig.json
+yarn-error.log

--- a/packages/avro-epoch-days/LICENSE
+++ b/packages/avro-epoch-days/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019-2020 OVO Energy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/avro-epoch-days/README.md
+++ b/packages/avro-epoch-days/README.md
@@ -8,7 +8,7 @@ A Logical type for representing a date stored as the number of days since epoch
 yarn add @ovotech/avro-epoch-days
 ```
 
-And then you can use `AvroEpochDays` for a logicalType of a feild.
+And then you can use `AvroEpochDays` for a logicalType of a field.
 
 > [examples/simple.ts](examples/simple.ts)
 

--- a/packages/avro-epoch-days/README.md
+++ b/packages/avro-epoch-days/README.md
@@ -1,0 +1,108 @@
+# Avro Epoch Days
+
+A Logical type for representing a date stored as the number of days since epoch
+
+### Using
+
+```bash
+yarn add @ovotech/avro-epoch-days
+```
+
+And then you can use `AvroEpochDays` for a logicalType of a feild.
+
+> [examples/simple.ts](examples/simple.ts)
+
+```typescript
+import { Type, Schema } from 'avsc';
+import { AvroEpochDays } from '@ovotech/avro-epoch-days';
+
+const eventSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'int', logicalType: 'date' },
+    },
+  ],
+};
+
+const EventType = Type.forSchema(eventSchema, { logicalTypes: { date: AvroEpochDays } });
+
+const encoded = EventType.toBuffer({ field1: new Date('2020-01-01') });
+const decoded = EventType.fromBuffer(encoded);
+
+console.log(decoded);
+```
+
+It also supports schema evolution from int, logical:date and string types
+
+> [examples/evolution.ts](examples/evolution.ts)
+
+```typescript
+import { Type, Schema } from 'avsc';
+import { AvroEpochDays } from '@ovotech/avro-epoch-days';
+
+const previousSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'string' },
+    },
+  ],
+};
+
+const eventSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'int', logicalType: 'date' },
+    },
+  ],
+};
+
+const PreviousType = Type.forSchema(previousSchema);
+const EventType = Type.forSchema(eventSchema, {
+  logicalTypes: { date: AvroEpochDays },
+});
+const previousTypeResolver = EventType.createResolver(PreviousType);
+
+const encoded = PreviousType.toBuffer({ field1: '2020-01-01' });
+const decoded = EventType.fromBuffer(encoded, previousTypeResolver);
+
+console.log(decoded);
+```
+
+## Running the tests
+
+Then you can run the tests with:
+
+```bash
+yarn test
+```
+
+### Coding style (linting, etc) tests
+
+Style is maintained with prettier and tslint
+
+```
+yarn lint
+```
+
+## Deployment
+
+Deployment is preferment by lerna automatically on merge / push to master, but you'll need to bump the package version numbers yourself. Only updated packages with newer versions will be pushed to the npm registry.
+
+## Contributing
+
+Have a bug? File an issue with a simple example that reproduces this so we can take a look & confirm.
+
+Want to make a change? Submit a PR, explain why it's useful, and make sure you've updated the docs (this file) and the tests (see [test folder](test)).
+
+## License
+
+This project is licensed under Apache 2 - see the [LICENSE](LICENSE) file for details

--- a/packages/avro-epoch-days/examples/evolution.ts
+++ b/packages/avro-epoch-days/examples/evolution.ts
@@ -1,0 +1,35 @@
+import { Type, Schema } from 'avsc';
+import { AvroEpochDays } from '@ovotech/avro-epoch-days';
+
+const previousSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'string' },
+    },
+  ],
+};
+
+const eventSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'int', logicalType: 'date' },
+    },
+  ],
+};
+
+const PreviousType = Type.forSchema(previousSchema);
+const EventType = Type.forSchema(eventSchema, {
+  logicalTypes: { date: AvroEpochDays },
+});
+const previousTypeResolver = EventType.createResolver(PreviousType);
+
+const encoded = PreviousType.toBuffer({ field1: '2020-01-01' });
+const decoded = EventType.fromBuffer(encoded, previousTypeResolver);
+
+console.log(decoded);

--- a/packages/avro-epoch-days/examples/simple.ts
+++ b/packages/avro-epoch-days/examples/simple.ts
@@ -1,0 +1,20 @@
+import { Type, Schema } from 'avsc';
+import { AvroEpochDays } from '@ovotech/avro-epoch-days';
+
+const eventSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'int', logicalType: 'date' },
+    },
+  ],
+};
+
+const EventType = Type.forSchema(eventSchema, { logicalTypes: { date: AvroEpochDays } });
+
+const encoded = EventType.toBuffer({ field1: new Date('2020-01-01') });
+const decoded = EventType.fromBuffer(encoded);
+
+console.log(decoded);

--- a/packages/avro-epoch-days/package.json
+++ b/packages/avro-epoch-days/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@ovotech/avro-epoch-days",
+  "description": "A logical type representing Date as epoch days",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "author": "Ivan Kerin <ikerin@gmail.com>",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest --runInBand",
+    "lint:prettier": "prettier --list-different {src,test}/**/*.ts",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint": "yarn lint:prettier && yarn lint:eslint",
+    "build": "tsc --outDir dist --declaration",
+    "build:docs": "build-docs README.md"
+  },
+  "devDependencies": {
+    "avsc": "^5.4.18",
+    "eslint-config-prettier": "^6.10.0",
+    "jest": "^25.1.0",
+    "prettier": "^1.19.1",
+    "ts-jest": "^25.2.1",
+    "ts-node": "^8.6.2"
+  },
+  "peerDependencies": {
+    "avsc": "^5.4.18"
+  },
+  "jest": {
+    "preset": "../../jest.json"
+  }
+}

--- a/packages/avro-epoch-days/src/index.ts
+++ b/packages/avro-epoch-days/src/index.ts
@@ -1,0 +1,35 @@
+import { Type, types } from 'avsc';
+
+const millisecondsInADay = 8.64e7;
+
+/**
+ * Custom logical type used to encode native Date objects as int.
+ */
+export class AvroEpochDays extends types.LogicalType {
+  _fromValue(val: number): Date {
+    return new Date(val * millisecondsInADay);
+  }
+
+  _fromStringValue(val: string): Date {
+    return new Date(val);
+  }
+
+  _toValue(date: Date): number;
+  _toValue<T>(date: T): T;
+  _toValue(value: unknown): unknown {
+    if (value instanceof Date) {
+      return Math.floor(value.getTime() / millisecondsInADay);
+    } else {
+      return value;
+    }
+  }
+
+  _resolve(type: Type): unknown {
+    if (Type.isType(type, 'int', 'logical:date')) {
+      return this._fromValue;
+    } else if (Type.isType(type, 'string')) {
+      return this._fromStringValue;
+    }
+    return undefined;
+  }
+}

--- a/packages/avro-epoch-days/test/integration.spec.ts
+++ b/packages/avro-epoch-days/test/integration.spec.ts
@@ -1,0 +1,64 @@
+import { AvroEpochDays } from '../src';
+import { Type } from 'avsc';
+
+const IntType = Type.forSchema(
+  {
+    type: 'record',
+    name: 'Event',
+    fields: [{ name: 'field1', type: { type: 'int' } }],
+  },
+  {},
+);
+
+const StringType = Type.forSchema(
+  {
+    type: 'record',
+    name: 'Event',
+    fields: [{ name: 'field1', type: { type: 'string' } }],
+  },
+  {},
+);
+
+const TestType = Type.forSchema(
+  {
+    type: 'record',
+    name: 'Event',
+    fields: [{ name: 'field1', type: { type: 'int', logicalType: 'date' } }],
+  },
+  { logicalTypes: { date: AvroEpochDays } },
+);
+
+describe('Integration', () => {
+  it('Should encode date correctly', async () => {
+    const data = { field1: new Date('2020-01-01T00:00:00.000Z') };
+    const encoded = TestType.toBuffer(data);
+    const decoded = TestType.fromBuffer(encoded);
+
+    expect(decoded.field1).toEqual(data.field1);
+  });
+
+  it('Should encode int correctly', async () => {
+    const data = { field1: 17687 };
+    const encoded = TestType.toBuffer(data);
+    const decoded = TestType.fromBuffer(encoded);
+
+    expect(decoded.field1).toEqual(new Date('2018-06-05T00:00:00.000Z'));
+  });
+
+  it('Should load binary data', async () => {
+    const data = { field1: 10000 };
+    const encoded = IntType.toBuffer(data);
+    const decoded = TestType.fromBuffer(encoded);
+
+    expect(decoded.field1).toEqual(new Date('1997-05-19T00:00:00.000Z'));
+  });
+
+  it('Should support schema evolution from string correctly', async () => {
+    const data = { field1: '2020-01-01T00:00:00.000Z' };
+    const encoded = StringType.toBuffer(data);
+    const resolver = TestType.createResolver(StringType);
+    const decoded = TestType.fromBuffer(encoded, resolver);
+
+    expect(decoded.field1).toEqual(new Date('2020-01-01T00:00:00.000Z'));
+  });
+});

--- a/packages/avro-epoch-days/tsconfig.json
+++ b/packages/avro-epoch-days/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/avro-timestamp-millis/.npmignore
+++ b/packages/avro-timestamp-millis/.npmignore
@@ -1,0 +1,7 @@
+.*
+test/
+src/
+examples/
+coverage/
+tsconfig.json
+yarn-error.log

--- a/packages/avro-timestamp-millis/LICENSE
+++ b/packages/avro-timestamp-millis/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019-2020 OVO Energy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/avro-timestamp-millis/README.md
+++ b/packages/avro-timestamp-millis/README.md
@@ -1,0 +1,110 @@
+# Avro Date
+
+A Logical type for representing a date stored as the number of milliseconds since epoch
+
+### Using
+
+```bash
+yarn add @ovotech/avro-epoch-days
+```
+
+And then you can use `AvroEpochDays` for a logicalType of a feild.
+
+> [examples/simple.ts](examples/simple.ts)
+
+```typescript
+import { Type, Schema } from 'avsc';
+import { AvroTimestampMillis } from '@ovotech/avro-timestamp-millis';
+
+const eventSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'long', logicalType: 'timestamp-millis' },
+    },
+  ],
+};
+
+const EventType = Type.forSchema(eventSchema, {
+  logicalTypes: { 'timestamp-millis': AvroTimestampMillis },
+});
+
+const encoded = EventType.toBuffer({ field1: new Date('2020-01-01') });
+const decoded = EventType.fromBuffer(encoded);
+
+console.log(decoded);
+```
+
+It also supports schema evolution from int, logical:date and string types
+
+> [examples/evolution.ts](examples/evolution.ts)
+
+```typescript
+import { Type, Schema } from 'avsc';
+import { AvroTimestampMillis } from '@ovotech/avro-timestamp-millis';
+
+const previousSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'string' },
+    },
+  ],
+};
+
+const eventSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'long', logicalType: 'timestamp-millis' },
+    },
+  ],
+};
+
+const PreviousType = Type.forSchema(previousSchema);
+const EventType = Type.forSchema(eventSchema, {
+  logicalTypes: { 'timestamp-millis': AvroTimestampMillis },
+});
+const previousTypeResolver = EventType.createResolver(PreviousType);
+
+const encoded = PreviousType.toBuffer({ field1: '2020-01-01' });
+const decoded = EventType.fromBuffer(encoded, previousTypeResolver);
+
+console.log(decoded);
+```
+
+## Running the tests
+
+Then you can run the tests with:
+
+```bash
+yarn test
+```
+
+### Coding style (linting, etc) tests
+
+Style is maintained with prettier and tslint
+
+```
+yarn lint
+```
+
+## Deployment
+
+Deployment is preferment by lerna automatically on merge / push to master, but you'll need to bump the package version numbers yourself. Only updated packages with newer versions will be pushed to the npm registry.
+
+## Contributing
+
+Have a bug? File an issue with a simple example that reproduces this so we can take a look & confirm.
+
+Want to make a change? Submit a PR, explain why it's useful, and make sure you've updated the docs (this file) and the tests (see [test folder](test)).
+
+## License
+
+This project is licensed under Apache 2 - see the [LICENSE](LICENSE) file for details

--- a/packages/avro-timestamp-millis/README.md
+++ b/packages/avro-timestamp-millis/README.md
@@ -8,7 +8,7 @@ A Logical type for representing a date stored as the number of milliseconds sinc
 yarn add @ovotech/avro-epoch-days
 ```
 
-And then you can use `AvroEpochDays` for a logicalType of a feild.
+And then you can use `AvroEpochDays` for a logicalType of a field.
 
 > [examples/simple.ts](examples/simple.ts)
 

--- a/packages/avro-timestamp-millis/examples/evolution.ts
+++ b/packages/avro-timestamp-millis/examples/evolution.ts
@@ -1,0 +1,35 @@
+import { Type, Schema } from 'avsc';
+import { AvroTimestampMillis } from '@ovotech/avro-timestamp-millis';
+
+const previousSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'string' },
+    },
+  ],
+};
+
+const eventSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'long', logicalType: 'timestamp-millis' },
+    },
+  ],
+};
+
+const PreviousType = Type.forSchema(previousSchema);
+const EventType = Type.forSchema(eventSchema, {
+  logicalTypes: { 'timestamp-millis': AvroTimestampMillis },
+});
+const previousTypeResolver = EventType.createResolver(PreviousType);
+
+const encoded = PreviousType.toBuffer({ field1: '2020-01-01' });
+const decoded = EventType.fromBuffer(encoded, previousTypeResolver);
+
+console.log(decoded);

--- a/packages/avro-timestamp-millis/examples/simple.ts
+++ b/packages/avro-timestamp-millis/examples/simple.ts
@@ -1,0 +1,22 @@
+import { Type, Schema } from 'avsc';
+import { AvroTimestampMillis } from '@ovotech/avro-timestamp-millis';
+
+const eventSchema: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    {
+      name: 'field1',
+      type: { type: 'long', logicalType: 'timestamp-millis' },
+    },
+  ],
+};
+
+const EventType = Type.forSchema(eventSchema, {
+  logicalTypes: { 'timestamp-millis': AvroTimestampMillis },
+});
+
+const encoded = EventType.toBuffer({ field1: new Date('2020-01-01') });
+const decoded = EventType.fromBuffer(encoded);
+
+console.log(decoded);

--- a/packages/avro-timestamp-millis/package.json
+++ b/packages/avro-timestamp-millis/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@ovotech/avro-timestamp-millis",
+  "description": "A logical type representing Date as long number",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "author": "Ivan Kerin <ikerin@gmail.com>",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest --runInBand",
+    "lint:prettier": "prettier --list-different {src,test}/**/*.ts",
+    "lint:eslint": "eslint '{src,test}/**/*.ts'",
+    "lint": "yarn lint:prettier && yarn lint:eslint",
+    "build": "tsc --outDir dist --declaration",
+    "build:docs": "build-docs README.md"
+  },
+  "devDependencies": {
+    "avsc": "^5.4.18",
+    "eslint-config-prettier": "^6.10.0",
+    "jest": "^25.1.0",
+    "prettier": "^1.19.1",
+    "ts-jest": "^25.2.1",
+    "ts-node": "^8.6.2"
+  },
+  "peerDependencies": {
+    "avsc": "^5.4.18"
+  },
+  "jest": {
+    "preset": "../../jest.json"
+  }
+}

--- a/packages/avro-timestamp-millis/src/index.ts
+++ b/packages/avro-timestamp-millis/src/index.ts
@@ -1,0 +1,23 @@
+import { Type, types } from 'avsc';
+
+/**
+ * Custom logical type used to encode native Date objects as long.
+ */
+export class AvroTimestampMillis extends types.LogicalType {
+  _fromValue(val: number): Date {
+    return new Date(val);
+  }
+
+  _toValue(date: Date): number;
+  _toValue<T>(date: T): T;
+  _toValue(date: unknown): unknown {
+    return date instanceof Date ? date.getTime() : date;
+  }
+
+  _resolve(type: Type): unknown {
+    if (Type.isType(type, 'int', 'string', 'logical:timestamp-millis')) {
+      return this._fromValue;
+    }
+    return undefined;
+  }
+}

--- a/packages/avro-timestamp-millis/test/integration.spec.ts
+++ b/packages/avro-timestamp-millis/test/integration.spec.ts
@@ -1,0 +1,64 @@
+import { AvroTimestampMillis } from '../src';
+import { Type } from 'avsc';
+
+const IntType = Type.forSchema(
+  {
+    type: 'record',
+    name: 'Event',
+    fields: [{ name: 'field1', type: { type: 'long' } }],
+  },
+  {},
+);
+
+const StringType = Type.forSchema(
+  {
+    type: 'record',
+    name: 'Event',
+    fields: [{ name: 'field1', type: { type: 'string' } }],
+  },
+  {},
+);
+
+const TestType = Type.forSchema(
+  {
+    type: 'record',
+    name: 'Event',
+    fields: [{ name: 'field1', type: { type: 'long', logicalType: 'timestamp-millis' } }],
+  },
+  { logicalTypes: { 'timestamp-millis': AvroTimestampMillis } },
+);
+
+describe('Integration', () => {
+  it('Should encode date correctly', async () => {
+    const data = { field1: new Date('2020-01-01T00:00:00.000Z') };
+    const encoded = TestType.toBuffer(data);
+    const decoded = TestType.fromBuffer(encoded);
+
+    expect(decoded.field1).toEqual(data.field1);
+  });
+
+  it('Should encode int correctly', async () => {
+    const data = { field1: 1000000000000 };
+    const encoded = TestType.toBuffer(data);
+    const decoded = TestType.fromBuffer(encoded);
+
+    expect(decoded.field1).toEqual(new Date('2001-09-09T01:46:40.000Z'));
+  });
+
+  it('Should load binary data', async () => {
+    const data = { field1: 1000000000000 };
+    const encoded = IntType.toBuffer(data);
+    const decoded = TestType.fromBuffer(encoded);
+
+    expect(decoded.field1).toEqual(new Date('2001-09-09T01:46:40.000Z'));
+  });
+
+  it('Should support schema evolution from string correctly', async () => {
+    const data = { field1: '2020-01-01T00:00:00.000Z' };
+    const encoded = StringType.toBuffer(data);
+    const resolver = TestType.createResolver(StringType);
+    const decoded = TestType.fromBuffer(encoded, resolver);
+
+    expect(decoded.field1).toEqual(new Date('2020-01-01T00:00:00.000Z'));
+  });
+});

--- a/packages/avro-timestamp-millis/tsconfig.json
+++ b/packages/avro-timestamp-millis/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Extract only the types that we actually use. Separate them into different packages so their dependencies don't get mixed together.

Epoch Days and Timestamp Millies are now able to evolve from string values.

Decimal is kept as-is.