### PR TITLE
Don't require consumers option

### DIFF
--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",

--- a/packages/castle/src/castle.ts
+++ b/packages/castle/src/castle.ts
@@ -64,7 +64,7 @@ export const createCastle = (config: CastleConfig): Castle => {
   producer.on('producer.disconnect', () => servicesStatus.set(producer, false));
   producer.on('producer.network.request', () => servicesStatus.set(producer, true));
 
-  const consumers: CastleConsumer[] = config.consumers.map(config => {
+  const consumers: CastleConsumer[] = (config.consumers || []).map(config => {
     const finalConfig = toFinalCastleConsumerConfig(config);
     const instance = kafka.consumer(finalConfig);
     servicesStatus.set(instance, false);

--- a/packages/castle/src/types.ts
+++ b/packages/castle/src/types.ts
@@ -77,7 +77,7 @@ export interface CastleConfig {
   producer?: ProducerConfig;
   admin?: AdminConfig;
   schemaRegistry: SchemaRegistryConfig;
-  consumers: CastleConsumerConfig[];
+  consumers?: CastleConsumerConfig[];
 }
 
 export interface CastleService {


### PR DESCRIPTION
I'm adding Castle to a project that only produces messages. In this context it makes no sense for the option to require an empty array of consumers.