### PR TITLE
Expose the original message buffer when consuming

### DIFF
--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/avro-kafkajs",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A wrapper around Kafkajs to transparently use Schema Registry for producing and consuming messages with avro schemas.",

--- a/packages/avro-kafkajs/src/types.ts
+++ b/packages/avro-kafkajs/src/types.ts
@@ -38,6 +38,7 @@ export interface AvroKafkaMessage<T = unknown, KT = KafkaMessage['key']>
   extends Omit<KafkaMessage, 'value' | 'key'> {
   schema: Schema;
   key: KT;
+  rawValue: Buffer;
   value: T;
 }
 

--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/blaise",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "An API to generate mock payloads for @ovotech/castle using @ovotech/avro-mock-generator",
   "keywords": [
     "castle",
@@ -39,7 +39,7 @@
     "preset": "../../jest.json"
   },
   "devDependencies": {
-    "@ovotech/avro-kafkajs": "^0.2.0",
+    "@ovotech/avro-kafkajs": "^1.0.0",
     "@ovotech/castle": "^0.4.1",
     "@types/lodash.merge": "^4.6.6",
     "@typescript-eslint/eslint-plugin": "^2.26.0",

--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@ovotech/avro-kafkajs": "^1.0.0",
-    "@ovotech/castle": "^0.4.1",
+    "@ovotech/castle": "^1.0.0",
     "@types/lodash.merge": "^4.6.6",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",

--- a/packages/blaise/src/index.ts
+++ b/packages/blaise/src/index.ts
@@ -40,6 +40,7 @@ export const defaultPayload: BlaiseDefaults = {
   message: {
     schema: [],
     key: Buffer.from('blaise-default-key'),
+    rawValue: Buffer.from('blaise-default-raw-value'),
     value: {},
     timestamp: Date.now().toString(),
     size: 3,

--- a/packages/castle-cli/package.json
+++ b/packages/castle-cli/package.json
@@ -38,7 +38,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.3.0",
+    "@ovotech/avro-kafkajs": "^1.0.0",
     "ansi-regex": "^5.0.0",
     "chalk": "^4.0.0",
     "commander": "^5.0.0",

--- a/packages/castle-stream/package.json
+++ b/packages/castle-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle-stream",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A node stream implementation of castle",
@@ -36,6 +36,6 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/castle": "^0.4.6"
+    "@ovotech/castle": "^1.0.0"
   }
 }

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.4.6",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",
@@ -40,7 +40,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.3.0",
+    "@ovotech/avro-kafkajs": "^1.0.0",
     "kafkajs": "^1.12.0",
     "lodash.chunk": "^4.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,6 +1308,15 @@
     mersenne-twister "^1.1.0"
     uuid "^7.0.2"
 
+"@ovotech/castle@^0.4.6":
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/@ovotech/castle/-/castle-0.4.6.tgz#68d772b452964f24b3f057c11edb3b2701390cac"
+  integrity sha512-rKQEO9JDwSAN8wJkGA7rfjar/rIduJWjOFck5AzdFZI8Hkl3E9RFUcWNV07BFigqdcPF3g6roS9ve5aBRS61Zw==
+  dependencies:
+    "@ovotech/avro-kafkajs" "^0.3.0"
+    kafkajs "^1.12.0"
+    lodash.chunk "^4.2.0"
+
 "@ovotech/schema-registry-api@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@ovotech/schema-registry-api/-/schema-registry-api-1.0.5.tgz#95914deba765ee9e8ec7523b34de744028f0c934"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,10 +1284,10 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
-"@ovotech/avro-kafkajs@^0.2.0":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@ovotech/avro-kafkajs/-/avro-kafkajs-0.2.2.tgz#ce21f2c3bd53c10a76bc926ee9849d2d49133ad3"
-  integrity sha512-uo82nva6zwBmsFZaE+g+Z4YuWontN7TDYrjci03/RcJdcbbSAzw+Siee9Wh9NmUSQJdbh9SAMuUSG01gpgrnRw==
+"@ovotech/avro-kafkajs@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@ovotech/avro-kafkajs/-/avro-kafkajs-0.3.0.tgz#39456cb5869165bbd83247f823f423379e1c6ef7"
+  integrity sha512-+XNOCkiYOLk+YAyYH/PTYDJji4WLC/oNSHkGD+FISzPq/YRAs1QxAyDmoxqbrzrJjOzlTAciJ0PLV+NrN63piQ==
   dependencies:
     "@ovotech/schema-registry-api" "^1.0.5"
     avsc "^5.4.21"


### PR DESCRIPTION
I'm looking into doing some message wrangling (re-keying with aggregation), and I think I need the orginial un-serialized buffer in order to achieve this and support schema versions bumps without needing to change anything.

Technically I could re-parse the value into a buffer, using the schema in the message but I'd like to keep the serialization to a minimum.

Without this changes the message would go through:
kafka -> avsc -> (my code) ->  toJSON -> database -> fromJSON ->  (my code) -> avsc -> kafka

With this change it would become
kafka -> (my code) -> database -> avsc -> (my code) -> avsc -> kafka

I chose a major version bump for all components where the added type would break code. There's no guarantee it would break any runtime, but it will break any tests crafting KafkaMessages manually.