### PR TITLE
Produce messages with custom subject

### DIFF
--- a/packages/avro-kafkajs/examples/custom-subject.ts
+++ b/packages/avro-kafkajs/examples/custom-subject.ts
@@ -1,0 +1,48 @@
+import { Kafka } from 'kafkajs';
+import { SchemaRegistry, AvroKafka } from '@ovotech/avro-kafkajs';
+import { Schema } from 'avsc';
+
+const mySchema: Schema = {
+  type: 'record',
+  name: 'MyMessage',
+  fields: [{ name: 'field1', type: 'string' }],
+};
+
+// Typescript types for the schema
+interface MyMessage {
+  field1: string;
+}
+
+const main = async () => {
+  const schemaRegistry = new SchemaRegistry({ uri: 'http://localhost:8081' });
+  const kafka = new Kafka({ brokers: ['localhost:29092'] });
+  const avroKafka = new AvroKafka(schemaRegistry, kafka);
+
+  // Consuming
+  const consumer = avroKafka.consumer({ groupId: 'my-group' });
+  await consumer.connect();
+  await consumer.subscribe({ topic: 'my-topic' });
+  await consumer.run<MyMessage>({
+    eachMessage: async ({ message }) => {
+      console.log(message.value);
+    },
+  });
+
+  // Producing
+  const producer = avroKafka.producer();
+  await producer.connect();
+  await producer.send<MyMessage>({
+    topic: 'my-topic',
+    schema: mySchema,
+    messages: [{ value: { field1: 'my-string' } }],
+  });
+
+  // Producing with custom subject
+  await producer.send<MyMessage>({
+    topic: 'my-topic',
+    subject: 'my-topic-value',
+    messages: [{ value: { field1: 'my-string-2' } }],
+  });
+};
+
+main();

--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/avro-kafkajs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A wrapper around Kafkajs to transparently use Schema Registry for producing and consuming messages with avro schemas.",

--- a/packages/avro-kafkajs/src/index.ts
+++ b/packages/avro-kafkajs/src/index.ts
@@ -34,6 +34,7 @@ export {
   AvroProducerRecord,
   AvroTopicMessages,
   AvroProducerBatch,
+  AvroProducerRecordSchema,
   AvroConsumerRun,
   TopicsAlias,
 } from './types';

--- a/packages/avro-kafkajs/src/types.ts
+++ b/packages/avro-kafkajs/src/types.ts
@@ -47,19 +47,19 @@ export interface AvroMessage<T = unknown, KT = Message['key']>
   value: T;
 }
 
-export interface AvroProducerRecord<T = unknown, KT = Message['key']>
-  extends Omit<ProducerRecord, 'messages'> {
-  schema: Schema;
-  keySchema?: Schema;
-  messages: AvroMessage<T, KT>[];
-}
+export type AvroProducerRecordSchema =
+  | { schema: Schema; keySchema?: Schema }
+  | { subject: string; keySubject?: string };
 
-export interface AvroTopicMessages<T = unknown, KT = Message['key']>
-  extends Omit<TopicMessages, 'messages'> {
-  schema: Schema;
-  keySchema?: Schema;
-  messages: AvroMessage<T, KT>[];
-}
+export type AvroProducerRecord<T = unknown, KT = Message['key']> = Omit<
+  ProducerRecord,
+  'messages'
+> & { messages: AvroMessage<T, KT>[] } & AvroProducerRecordSchema;
+
+export type AvroTopicMessages<T = unknown, KT = Message['key']> = Omit<
+  TopicMessages,
+  'messages'
+> & { messages: AvroMessage<T, KT>[] } & AvroProducerRecordSchema;
 
 export interface AvroProducerBatch extends Omit<ProducerBatch, 'topicMessages'> {
   topicMessages: AvroTopicMessages<unknown, unknown>[];

--- a/packages/avro-kafkajs/test/functions.spec.ts
+++ b/packages/avro-kafkajs/test/functions.spec.ts
@@ -114,19 +114,33 @@ describe('Functions', () => {
       },
     });
 
-    const value1 = await schemaRegistry.encode<MessageType>(topic, 'value', schema, {
-      intField: 10,
-      stringField: 'test1',
+    const value1 = await schemaRegistry.encode<MessageType>({
+      topic,
+      schemaType: 'value',
+      schema,
+      value: { intField: 10, stringField: 'test1' },
     });
 
-    const key1 = await schemaRegistry.encode<KeyType>(topic, 'key', keySchema, 101);
-
-    const value2 = await schemaRegistry.encode<MessageType>(topic, 'value', schema, {
-      intField: null,
-      stringField: 'test2',
+    const key1 = await schemaRegistry.encode<KeyType>({
+      topic,
+      schemaType: 'key',
+      schema: keySchema,
+      value: 101,
     });
 
-    const key2 = await schemaRegistry.encode<KeyType>(topic, 'key', keySchema, 102);
+    const value2 = await schemaRegistry.encode<MessageType>({
+      topic,
+      schemaType: 'value',
+      schema,
+      value: { intField: null, stringField: 'test2' },
+    });
+
+    const key2 = await schemaRegistry.encode<KeyType>({
+      topic,
+      schemaType: 'key',
+      schema: keySchema,
+      value: 102,
+    });
 
     await producer.send({
       topic,

--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -39,8 +39,8 @@
     "preset": "../../jest.json"
   },
   "devDependencies": {
-    "@ovotech/avro-kafkajs": "^0.4.0",
-    "@ovotech/castle": "^0.4.1",
+    "@ovotech/avro-kafkajs": "^0.5.0",
+    "@ovotech/castle": "^0.5.0",
     "@types/lodash.merge": "^4.6.6",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",

--- a/packages/castle-cli/package.json
+++ b/packages/castle-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle-cli",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka avro cli",
@@ -38,7 +38,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.4.0",
+    "@ovotech/avro-kafkajs": "^0.5.0",
     "ansi-regex": "^5.0.0",
     "chalk": "^4.0.0",
     "commander": "^5.0.0",

--- a/packages/castle-stream/package.json
+++ b/packages/castle-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle-stream",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A node stream implementation of castle",
@@ -36,6 +36,6 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/castle": "^0.4.7"
+    "@ovotech/castle": "^0.5.0"
   }
 }

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",
@@ -40,7 +40,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.4.0",
+    "@ovotech/avro-kafkajs": "^0.5.0",
     "kafkajs": "^1.12.0",
     "lodash.chunk": "^4.2.0"
   }

--- a/packages/castle/src/castle.ts
+++ b/packages/castle/src/castle.ts
@@ -1,11 +1,11 @@
-import { Kafka, KafkaMessage } from 'kafkajs';
+import { Kafka, KafkaMessage, ProducerRecord } from 'kafkajs';
 import {
   AvroConsumerRun,
   AvroKafka,
   AvroProducer,
   SchemaRegistry,
-  AvroProducerRecord,
   AvroConsumer,
+  AvroProducerRecordSchema,
 } from '@ovotech/avro-kafkajs';
 import {
   CastleConsumerConfig,
@@ -30,7 +30,10 @@ const withProducer = <TValue = unknown, TKey = KafkaMessage['key']>(producer: Av
   }
 };
 
-export const produce = <T>(config: Omit<AvroProducerRecord<T>, 'messages'>): CastleSender<T> => {
+export const produce = <T>(
+  config: Omit<ProducerRecord, 'messages'> & AvroProducerRecordSchema,
+): CastleSender<T> => {
+  config;
   return (producer, messages) => producer.send<T>({ ...config, messages });
 };
 


### PR DESCRIPTION
This is a bit more inobtrusive change to achieve #33
If it's does the job we can close #33

With these types we can make sure you can't add subject & schemaKey for example or any other combinations of parameters that we know are not correct.
Also this has the benefit of being a backwards compatible change.