### PR TITLE
Add "long" library to avro-kafkajs dependencies

### DIFF
--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@ovotech/schema-registry-api": "^1.0.7",
-    "avsc": "^5.4.22"
+    "avsc": "^5.4.22",
+    "long": "^4.0.0"
   }
 }

--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@ovotech/build-docs": "^0.1.0",
     "@types/jest": "^26.0.14",
+    "@types/long": "^4.0.1",
     "@types/node": "^14.11.2",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.2.0",


### PR DESCRIPTION
Avro-KafkaJS is using this library, but it was not explicitly listed in the dependencies.