### PR TITLE
Add "long" library to avro-kafkajs dependencies

### DIFF
--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/avro-kafkajs",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A wrapper around Kafkajs to transparently use Schema Registry for producing and consuming messages with avro schemas.",

--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@ovotech/schema-registry-api": "^1.0.7",
-    "avsc": "^5.4.22"
+    "avsc": "^5.4.22",
+    "long": "^4.0.0"
   }
 }

--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@ovotech/build-docs": "^0.1.0",
     "@types/jest": "^26.0.14",
+    "@types/long": "^4.0.1",
     "@types/node": "^14.11.2",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.2.0",

--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/blaise",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "An API to generate mock payloads for @ovotech/castle using @ovotech/avro-mock-generator",
   "keywords": [
     "castle",
@@ -39,8 +39,8 @@
     "preset": "../../jest.json"
   },
   "devDependencies": {
-    "@ovotech/avro-kafkajs": "^0.5.0",
-    "@ovotech/castle": "^0.6.0",
+    "@ovotech/avro-kafkajs": "^0.5.5",
+    "@ovotech/castle": "^0.6.3",
     "@types/lodash.merge": "^4.6.6",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",

--- a/packages/castle-cli/package.json
+++ b/packages/castle-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle-cli",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka avro cli",
@@ -39,7 +39,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.5.4",
+    "@ovotech/avro-kafkajs": "^0.5.5",
     "ansi-regex": "^5.0.0",
     "chalk": "^4.1.0",
     "commander": "^6.1.0",

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",
@@ -41,7 +41,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.5.4",
+    "@ovotech/avro-kafkajs": "^0.5.5",
     "kafkajs": "^1.14.0",
     "lodash.chunk": "^4.2.0"
   }


### PR DESCRIPTION
Avro-KafkaJS is using this library, but it was not explicitly listed in the dependencies.