### PR TITLE
Add tombstone support to avro-kafkajs

### DIFF
--- a/packages/avro-kafkajs/src/types.ts
+++ b/packages/avro-kafkajs/src/types.ts
@@ -36,9 +36,9 @@ export type AvroEachBatch<T = unknown, KT = KafkaMessage['key']> = (
 
 export interface AvroKafkaMessage<T = unknown, KT = KafkaMessage['key']>
   extends Omit<KafkaMessage, 'value' | 'key'> {
-  schema: Schema;
+  schema: Schema | null;
   key: KT;
-  value: T;
+  value: T | null;
 }
 
 export interface AvroMessage<T = unknown, KT = Message['key']>


### PR DESCRIPTION
Currently Avro-kafkajs silently does nothing if we receive a null message because it does not handle that use case, with this change if the payload of the message is `null`, avro-kafkajs doesn't try to decode the message and forward `null` value and `null` schema.