### PR TITLE
Allow avro error records

### DIFF
--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts-cli",
   "description": "A cli to convert avro schemas into typescript interfaces",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-ts": "^6.0.2",
+    "@ovotech/avro-ts": "^6.0.3",
     "ansi-regex": "^5.0.0",
     "chalk": "^4.1.0",
     "commander": "^7.1.0"

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts",
   "description": "Convert avro schemas into typescript interfaces",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts/src/convert.ts
+++ b/packages/avro-ts/src/convert.ts
@@ -83,7 +83,7 @@ export const convertType: Convert = (context, type) => {
 
     return document(context, ref);
   } else {
-    throw new Error(`Cannot work out type ${type}`);
+    throw new Error(`Cannot work out type ${JSON.stringify(type)}`);
   }
 };
 

--- a/packages/avro-ts/src/types/record.ts
+++ b/packages/avro-ts/src/types/record.ts
@@ -5,7 +5,8 @@ import { convertType } from '../convert';
 import { firstUpperCase, namedType } from '../helpers';
 
 export const isRecordType = (type: Schema): type is avroSchema.RecordType =>
-  typeof type === 'object' && 'type' in type && type.type === 'record';
+  (typeof type === 'object' && 'type' in type && type.type === 'record') ||
+  (type as any).type === 'error';
 
 export const withDefault = (def: unknown, doc: string | undefined): string | undefined => {
   if (def === undefined) {

--- a/packages/avro-ts/test/__snapshots__/integration.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/integration.spec.ts.snap
@@ -1346,6 +1346,40 @@ export namespace UkCoBoostpowerSupportKafkaMessages {
 "
 `;
 
+exports[`Avro ts test Should convert EpicError.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type EpicFailure = Namespace.EpicFailure;
+
+export namespace Namespace {
+    export const ErrorCodeName = \\"namespace.ErrorCode\\";
+    export type ErrorCode = \\"ERROR\\";
+    export const EpicFailureName = \\"namespace.EpicFailure\\";
+    export interface EpicFailure {
+        code: Namespace.ErrorCode;
+        message: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert EpicError.avsc successfully with default as optional 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type EpicFailure = Namespace.EpicFailure;
+
+export namespace Namespace {
+    export const ErrorCodeName = \\"namespace.ErrorCode\\";
+    export type ErrorCode = \\"ERROR\\";
+    export const EpicFailureName = \\"namespace.EpicFailure\\";
+    export interface EpicFailure {
+        code: Namespace.ErrorCode;
+        message: string;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert M03.avsc successfully 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 

--- a/packages/avro-ts/test/avro/EpicError.avsc
+++ b/packages/avro-ts/test/avro/EpicError.avsc
@@ -1,0 +1,19 @@
+{
+  "type": "error",
+  "name": "EpicFailure",
+  "namespace": "namespace",
+  "fields": [
+    {
+      "name": "code",
+      "type": {
+        "type": "enum",
+        "name": "ErrorCode",
+        "symbols": ["ERROR"]
+      }
+    },
+    {
+      "name": "message",
+      "type": "string"
+    }
+  ]
+}


### PR DESCRIPTION
Avro has "error" records that are exactly ase normal "record"-s but with the keyword "error"

AVSC itself apparently supports this https://github.com/mtth/avsc/blob/75ed60ee2ac38785ec48386bc111e4a02a22c97e/lib/types.js#L34

But this is absent from the types https://github.com/mtth/avsc/blob/10225a0f2fd026f1a553e832875f4173764486a4/types/index.d.ts#L24-L25

While it is an issue with the underlying library, we can mitigate it for the type being by forcing the types until they fix the issue.

Should resolve #71
