### PR TITLE
Disallow missing keys

### DIFF
--- a/packages/avro-kafkajs/README.md
+++ b/packages/avro-kafkajs/README.md
@@ -179,13 +179,23 @@ const main = async () => {
   await producer.connect();
 
   // Encode the value
-  const value = await schemaRegistry.encode<MyMessage>('my-topic', 'value', mySchema, {
-    field1: 'my-string',
+  const value = await schemaRegistry.encode<MyMessage>({
+    topic: 'my-topic',
+    schemaType: 'value',
+    schema: mySchema,
+    value: {
+      field1: 'my-string',
+    },
   });
 
   // Optionally encode the key
-  const key = await schemaRegistry.encode<MyKey>('my-topic', 'key', myKeySchema, {
-    id: 10,
+  const key = await schemaRegistry.encode<MyKey>({
+    topic: 'my-topic',
+    schemaType: 'key',
+    schema: myKeySchema,
+    value: {
+      id: 10,
+    },
   });
   await producer.send({ topic: 'my-topic', messages: [{ value, key }] });
 };
@@ -223,7 +233,7 @@ const sendMyMessage = (producer: AvroProducer, message: MyMessage) =>
   producer.send<MyMessage>({
     topic: MY_TOPIC,
     schema: mySchema,
-    messages: [{ value: message }],
+    messages: [{ value: message, key: null }],
   });
 
 const main = async () => {
@@ -315,12 +325,12 @@ const main = async () => {
   await producer.send<MyOldMessage>({
     topic: 'my-topic-evolution',
     schema: myOldSchema,
-    messages: [{ value: { field1: 'my-string' } }],
+    messages: [{ value: { field1: 'my-string' }, key: null }],
   });
   await producer.send<MyNewMessage>({
     topic: 'my-topic-evolution',
     schema: myNewSchema,
-    messages: [{ value: { field1: 'my-string', field2: 'new-string' } }],
+    messages: [{ value: { field1: 'my-string', field2: 'new-string' }, key: null }],
   });
 };
 
@@ -370,14 +380,14 @@ const main = async () => {
   await producer.send<MyMessage>({
     topic: 'my-topic',
     schema: mySchema,
-    messages: [{ value: { field1: 'my-string' } }],
+    messages: [{ value: { field1: 'my-string' }, key: null }],
   });
 
   // Producing with custom subject
   await producer.send<MyMessage>({
     topic: 'my-topic',
     subject: 'my-topic-value',
-    messages: [{ value: { field1: 'my-string-2' } }],
+    messages: [{ value: { field1: 'my-string-2' }, key: null }],
   });
 };
 

--- a/packages/avro-kafkajs/examples/custom-subject.ts
+++ b/packages/avro-kafkajs/examples/custom-subject.ts
@@ -34,14 +34,14 @@ const main = async () => {
   await producer.send<MyMessage>({
     topic: 'my-topic',
     schema: mySchema,
-    messages: [{ value: { field1: 'my-string' } }],
+    messages: [{ value: { field1: 'my-string' }, key: null }],
   });
 
   // Producing with custom subject
   await producer.send<MyMessage>({
     topic: 'my-topic',
     subject: 'my-topic-value',
-    messages: [{ value: { field1: 'my-string-2' } }],
+    messages: [{ value: { field1: 'my-string-2' }, key: null }],
   });
 };
 

--- a/packages/avro-kafkajs/examples/schema-evolution.ts
+++ b/packages/avro-kafkajs/examples/schema-evolution.ts
@@ -55,12 +55,12 @@ const main = async () => {
   await producer.send<MyOldMessage>({
     topic: 'my-topic-evolution',
     schema: myOldSchema,
-    messages: [{ value: { field1: 'my-string' } }],
+    messages: [{ value: { field1: 'my-string' }, key: null }],
   });
   await producer.send<MyNewMessage>({
     topic: 'my-topic-evolution',
     schema: myNewSchema,
-    messages: [{ value: { field1: 'my-string', field2: 'new-string' } }],
+    messages: [{ value: { field1: 'my-string', field2: 'new-string' }, key: null }],
   });
 };
 

--- a/packages/avro-kafkajs/examples/schema-registry.ts
+++ b/packages/avro-kafkajs/examples/schema-registry.ts
@@ -45,13 +45,23 @@ const main = async () => {
   await producer.connect();
 
   // Encode the value
-  const value = await schemaRegistry.encode<MyMessage>('my-topic', 'value', mySchema, {
-    field1: 'my-string',
+  const value = await schemaRegistry.encode<MyMessage>({
+    topic: 'my-topic',
+    schemaType: 'value',
+    schema: mySchema,
+    value: {
+      field1: 'my-string',
+    },
   });
 
   // Optionally encode the key
-  const key = await schemaRegistry.encode<MyKey>('my-topic', 'key', myKeySchema, {
-    id: 10,
+  const key = await schemaRegistry.encode<MyKey>({
+    topic: 'my-topic',
+    schemaType: 'key',
+    schema: myKeySchema,
+    value: {
+      id: 10,
+    },
   });
   await producer.send({ topic: 'my-topic', messages: [{ value, key }] });
 };

--- a/packages/avro-kafkajs/examples/topics-aliases.ts
+++ b/packages/avro-kafkajs/examples/topics-aliases.ts
@@ -20,7 +20,7 @@ const sendMyMessage = (producer: AvroProducer, message: MyMessage) =>
   producer.send<MyMessage>({
     topic: MY_TOPIC,
     schema: mySchema,
-    messages: [{ value: message }],
+    messages: [{ value: message, key: null }],
   });
 
 const main = async () => {

--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/avro-kafkajs",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A wrapper around Kafkajs to transparently use Schema Registry for producing and consuming messages with avro schemas.",

--- a/packages/avro-kafkajs/src/types.ts
+++ b/packages/avro-kafkajs/src/types.ts
@@ -41,9 +41,9 @@ export interface AvroKafkaMessage<T = unknown, KT = KafkaMessage['key']>
   value: T | null;
 }
 
-export interface AvroMessage<T = unknown, KT = Message['key']>
+export interface AvroMessage<T = unknown, KT = Exclude<Message['key'], undefined>>
   extends Omit<Message, 'value' | 'key'> {
-  key?: KT;
+  key: KT;
   value: T;
 }
 

--- a/packages/avro-kafkajs/test/class.spec.ts
+++ b/packages/avro-kafkajs/test/class.spec.ts
@@ -482,7 +482,7 @@ describe('Class', () => {
     await producer.send<MessageType>({
       topic: TOPIC_ALIAS,
       schema,
-      messages: [{ value: { stringField: '1', intField: null } }],
+      messages: [{ value: { stringField: '1', intField: null }, key: null }],
     });
 
     // Use the subject directly to produce the messages
@@ -490,8 +490,8 @@ describe('Class', () => {
       topic: TOPIC_ALIAS,
       subject: `${realTopicName}-value`,
       messages: [
-        { value: { stringField: '2', intField: null } },
-        { value: { stringField: '3', intField: null } },
+        { value: { stringField: '2', intField: null }, key: null },
+        { value: { stringField: '3', intField: null }, key: null },
       ],
     });
 

--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/blaise",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "An API to generate mock payloads for @ovotech/castle using @ovotech/avro-mock-generator",
   "keywords": [
     "castle",
@@ -39,8 +39,8 @@
     "preset": "../../jest.json"
   },
   "devDependencies": {
-    "@ovotech/avro-kafkajs": "^0.6.1",
-    "@ovotech/castle": "^0.6.3",
+    "@ovotech/avro-kafkajs": "^0.7.0",
+    "@ovotech/castle": "^0.7.0",
     "@types/lodash.merge": "^4.6.6",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
     "@typescript-eslint/parser": "^4.15.1",

--- a/packages/castle-cli/package.json
+++ b/packages/castle-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle-cli",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka avro cli",
@@ -39,7 +39,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.6.3",
+    "@ovotech/avro-kafkajs": "^0.7.0",
     "ansi-regex": "^5.0.0",
     "chalk": "^4.1.0",
     "commander": "^7.1.0",

--- a/packages/castle-cli/src/commands/castle.ts
+++ b/packages/castle-cli/src/commands/castle.ts
@@ -8,7 +8,7 @@ import { Output } from '../output';
 export const castle = (output = new Output(console)): commander.Command =>
   commander
     .createCommand('castle')
-    .version('0.5.11')
+    .version('0.5.12')
     .description(
       `Castle CLI - a tool for inspecting kafka topics with schema registry.
 

--- a/packages/castle-cli/src/commands/topic/message.ts
+++ b/packages/castle-cli/src/commands/topic/message.ts
@@ -64,7 +64,7 @@ Example:
           const messages = [
             {
               value: JSON.parse(messageJson),
-              key: keySchema && key ? JSON.parse(key) : key,
+              key: (keySchema && key ? JSON.parse(key) : key) ?? null,
               partition,
             },
           ];

--- a/packages/castle-cli/src/commands/topic/produce.ts
+++ b/packages/castle-cli/src/commands/topic/produce.ts
@@ -13,6 +13,7 @@ import {
   Union,
   Dictionary,
   Partial,
+  Null,
 } from 'runtypes';
 import { readFileSync } from 'fs';
 import { Type, Schema } from 'avsc';
@@ -30,9 +31,8 @@ const TypeSchema = Unknown.withConstraint<Schema>((item: unknown) => {
 const ProduceFileType = Record({
   topic: String,
   messages: Array(
-    Record({ value: Unknown }).And(
+    Record({ value: Unknown, key: String.Or(Null) }).And(
       Partial({
-        key: String,
         partition: Number,
         headers: Dictionary(TypeBuffer),
         timestamp: String,

--- a/packages/castle-cli/test/produce-template.json
+++ b/packages/castle-cli/test/produce-template.json
@@ -13,43 +13,73 @@
   "messages": [
     {
       "partition": 0,
-      "value": { "field1": "test1" }
+      "value": {
+        "field1": "test1"
+      },
+      "key": null
     },
     {
       "partition": 1,
-      "value": { "field1": "test2" }
+      "value": {
+        "field1": "test2"
+      },
+      "key": null
     },
     {
       "partition": 2,
-      "value": { "field1": "test3" }
+      "value": {
+        "field1": "test3"
+      },
+      "key": null
     },
     {
       "partition": 0,
-      "value": { "field1": "test4" }
+      "value": {
+        "field1": "test4"
+      },
+      "key": null
     },
     {
       "partition": 0,
-      "value": { "field1": "test5" }
+      "value": {
+        "field1": "test5"
+      },
+      "key": null
     },
     {
       "partition": 1,
-      "value": { "field1": "test6" }
+      "value": {
+        "field1": "test6"
+      },
+      "key": null
     },
     {
       "partition": 1,
-      "value": { "field1": "test7" }
+      "value": {
+        "field1": "test7"
+      },
+      "key": null
     },
     {
       "partition": 1,
-      "value": { "field1": "test8" }
+      "value": {
+        "field1": "test8"
+      },
+      "key": null
     },
     {
       "partition": 2,
-      "value": { "field1": "test10" }
+      "value": {
+        "field1": "test10"
+      },
+      "key": null
     },
     {
       "partition": 2,
-      "value": { "field1": "test11" }
+      "value": {
+        "field1": "test11"
+      },
+      "key": null
     }
   ]
 }

--- a/packages/castle-stream/package.json
+++ b/packages/castle-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle-stream",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A node stream implementation of castle",
@@ -37,6 +37,6 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/castle": "^0.6.4"
+    "@ovotech/castle": "^0.7.0"
   }
 }

--- a/packages/castle-stream/test/integration.spec.ts
+++ b/packages/castle-stream/test/integration.spec.ts
@@ -62,6 +62,7 @@ const event2Consumer1: CastleStreamConsumerConfig<string, Event2, null> = {
       schema: Event1Schema,
       messages: messages.map((message) => ({
         value: { field1: `new-${message.value?.field2}` },
+        key: null,
       })),
     });
   },
@@ -75,7 +76,7 @@ const event2Consumer2: CastleStreamConsumerConfig<string, Event2, null> = {
     producer.send({
       topic: topic1,
       schema: Event1Schema,
-      messages: [{ value: { field1: `new-${message.value?.field2}` } }],
+      messages: [{ value: { field1: `new-${message.value?.field2}` }, key: null }],
     });
   },
 };

--- a/packages/castle/README.md
+++ b/packages/castle/README.md
@@ -36,7 +36,7 @@ const main = async () => {
 
   console.log(describeCastle(castle));
 
-  await mySender(castle.producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(castle.producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();
@@ -79,22 +79,22 @@ const sendFeedback = produce<FeedbackEvent>({ topic: Topic.Feedback, schema: Fee
 
 // Define a consumer as a pure function
 const eachStartEvent = consumeEachMessage<StartEvent>(async ({ message }) => {
-  console.log(`Started Processing ${message.value.id}`);
+  console.log(`Started Processing ${message.value?.id}`);
 });
 
 // Define a batch consumer as a pure function
 const eachBatchFeedbackEvent = consumeEachBatch<FeedbackEvent>(async ({ batch, producer }) => {
-  console.log(`Feedback ${batch.messages.map((msg) => `${msg.value.id}:${msg.value.status}`)}`);
+  console.log(`Feedback ${batch.messages.map((msg) => `${msg.value?.id}:${msg.value?.status}`)}`);
   console.log('Sending complete events');
   sendComplete(
     producer,
-    batch.messages.map((msg) => ({ value: { id: msg.value.id } })),
+    batch.messages.map((msg) => ({ value: { id: msg.value?.id ?? 0 }, key: null })),
   );
 });
 
 // Define a parallel consumer as a pure function
 const eachCompleteEvent = consumeEachMessage<CompleteEvent>(async ({ message }) => {
-  console.log(`Completed ${message.value.id}`);
+  console.log(`Completed ${message.value?.id}`);
 });
 
 const eachSizedBatch = consumeEachBatch(async ({ batch: { messages, partition } }) =>
@@ -154,15 +154,18 @@ const main = async () => {
 
   // Perform a siqeunce of events
   // - send start events, wait a bit
-  await sendStart(castle.producer, [{ value: { id: 10 } }, { value: { id: 20 } }]);
+  await sendStart(castle.producer, [
+    { value: { id: 10 }, key: null },
+    { value: { id: 20 }, key: null },
+  ]);
 
   // - wait a bit
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
   // - send feedback events which would produce the complete events
   await sendFeedback(castle.producer, [
-    { value: { id: 10, status: 'Sent' } },
-    { value: { id: 20, status: 'Failed' } },
+    { value: { id: 10, status: 'Sent' }, key: null },
+    { value: { id: 20, status: 'Failed' }, key: null },
   ]);
 };
 
@@ -212,7 +215,7 @@ const main = async () => {
 
   console.log(describeCastle(castle));
 
-  await mySender(castle.producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(castle.producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();
@@ -240,16 +243,16 @@ const complete = produce<CompleteEvent>({ topic: 'my-complete-3', schema: Comple
 
 const eachStart = consumeEachMessage<StartEvent, DbContext & LoggingContext>(
   async ({ message, db, logger, producer }) => {
-    logger.log('Started', message.value.id);
-    const { rows } = await db.query('SELECT avatar FROM users WHERE id = $1', [message.value.id]);
+    logger.log('Started', message.value?.id);
+    const { rows } = await db.query('SELECT avatar FROM users WHERE id = $1', [message.value?.id]);
     logger.log('Found', rows, 'Sending Complete');
-    complete(producer, [{ value: { id: message.value.id } }]);
+    complete(producer, [{ value: { id: message.value?.id ?? 0 }, key: null }]);
   },
 );
 
 const eachComplete = consumeEachMessage<CompleteEvent, LoggingContext>(
   async ({ message, logger }) => {
-    logger.log('Complete received for', message.value.id);
+    logger.log('Complete received for', message.value?.id);
   },
 );
 
@@ -284,7 +287,7 @@ const main = async () => {
 
   console.log(describeCastle(castle));
 
-  await start(castle.producer, [{ value: { id: 1 } }]);
+  await start(castle.producer, [{ value: { id: 1 }, key: null }]);
 };
 
 main();
@@ -333,7 +336,7 @@ const main = async () => {
 
   console.log(describeCastle(castle));
 
-  await mySender(castle.producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(castle.producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();
@@ -386,7 +389,7 @@ const main = async () => {
   console.log(describeCastle(castle));
 
   // You can use the stand alone producer elsewhere
-  await mySender(producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();

--- a/packages/castle/examples/optional.ts
+++ b/packages/castle/examples/optional.ts
@@ -34,7 +34,7 @@ const main = async () => {
 
   console.log(describeCastle(castle));
 
-  await mySender(castle.producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(castle.producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();

--- a/packages/castle/examples/parts.ts
+++ b/packages/castle/examples/parts.ts
@@ -36,7 +36,7 @@ const main = async () => {
   console.log(describeCastle(castle));
 
   // You can use the stand alone producer elsewhere
-  await mySender(producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();

--- a/packages/castle/examples/simple.ts
+++ b/packages/castle/examples/simple.ts
@@ -23,7 +23,7 @@ const main = async () => {
 
   console.log(describeCastle(castle));
 
-  await mySender(castle.producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(castle.producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();

--- a/packages/castle/examples/ssl-auth.ts
+++ b/packages/castle/examples/ssl-auth.ts
@@ -33,7 +33,7 @@ const main = async () => {
 
   console.log(describeCastle(castle));
 
-  await mySender(castle.producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(castle.producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();

--- a/packages/castle/examples/winston-logging.ts
+++ b/packages/castle/examples/winston-logging.ts
@@ -39,7 +39,7 @@ const main = async () => {
 
   winstonLogger.info('Started');
 
-  await mySender(castle.producer, [{ value: { field1: 'my-string' } }]);
+  await mySender(castle.producer, [{ value: { field1: 'my-string' }, key: null }]);
 };
 
 main();

--- a/packages/castle/examples/with-middlewares.ts
+++ b/packages/castle/examples/with-middlewares.ts
@@ -13,16 +13,16 @@ const complete = produce<CompleteEvent>({ topic: 'my-complete-3', schema: Comple
 
 const eachStart = consumeEachMessage<StartEvent, DbContext & LoggingContext>(
   async ({ message, db, logger, producer }) => {
-    logger.log('Started', message.value.id);
-    const { rows } = await db.query('SELECT avatar FROM users WHERE id = $1', [message.value.id]);
+    logger.log('Started', message.value?.id);
+    const { rows } = await db.query('SELECT avatar FROM users WHERE id = $1', [message.value?.id]);
     logger.log('Found', rows, 'Sending Complete');
-    complete(producer, [{ value: { id: message.value.id } }]);
+    complete(producer, [{ value: { id: message.value?.id ?? 0 }, key: null }]);
   },
 );
 
 const eachComplete = consumeEachMessage<CompleteEvent, LoggingContext>(
   async ({ message, logger }) => {
-    logger.log('Complete received for', message.value.id);
+    logger.log('Complete received for', message.value?.id);
   },
 );
 
@@ -57,7 +57,7 @@ const main = async () => {
 
   console.log(describeCastle(castle));
 
-  await start(castle.producer, [{ value: { id: 1 } }]);
+  await start(castle.producer, [{ value: { id: 1 }, key: null }]);
 };
 
 main();

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",
@@ -41,7 +41,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.6.3",
+    "@ovotech/avro-kafkajs": "^0.7.0",
     "kafkajs": "^1.15.0",
     "lodash.chunk": "^4.2.0"
   }

--- a/packages/castle/test/integration.spec.ts
+++ b/packages/castle/test/integration.spec.ts
@@ -129,24 +129,24 @@ describe('Integration', () => {
       await castle.start();
 
       await Promise.all([
-        sendEvent1(castle.producer, [{ value: { field1: 'test1' }, partition: 0 }]),
+        sendEvent1(castle.producer, [{ value: { field1: 'test1' }, partition: 0, key: null }]),
         sendEvent1(castle.producer, [
-          { value: { field1: 'test2' }, partition: 1 },
-          { value: { field1: 'test3' }, partition: 2 },
-          { value: { field1: 'test4' }, partition: 0 },
+          { value: { field1: 'test2' }, partition: 1, key: null },
+          { value: { field1: 'test3' }, partition: 2, key: null },
+          { value: { field1: 'test4' }, partition: 0, key: null },
         ]),
 
         sendEvent2(castle.producer, [
-          { value: { field2: 'test5' }, partition: 1 },
-          { value: { field2: 'test6' }, partition: 1 },
-          { value: { field2: 'test7' }, partition: 0 },
+          { value: { field2: 'test5' }, partition: 1, key: null },
+          { value: { field2: 'test6' }, partition: 1, key: null },
+          { value: { field2: 'test7' }, partition: 0, key: null },
         ]),
         sendEvent3(castle.producer, [
-          { value: { field2: 'p0m1' }, partition: 0 },
-          { value: { field2: 'p0m2' }, partition: 0 },
-          { value: { field2: 'p0m3' }, partition: 0 },
-          { value: { field2: 'p0m4' }, partition: 0 },
-          { value: { field2: 'p0m5' }, partition: 0 },
+          { value: { field2: 'p0m1' }, partition: 0, key: null },
+          { value: { field2: 'p0m2' }, partition: 0, key: null },
+          { value: { field2: 'p0m3' }, partition: 0, key: null },
+          { value: { field2: 'p0m4' }, partition: 0, key: null },
+          { value: { field2: 'p0m5' }, partition: 0, key: null },
         ]),
       ]);
 

--- a/packages/castle/test/lifecycle.spec.ts
+++ b/packages/castle/test/lifecycle.spec.ts
@@ -32,7 +32,7 @@ describe('Integration', () => {
       await castle.stop();
       expect(castle.isRunning()).toBe(false);
       await castle.start();
-      await sendEvent1(castle.producer, [{ value: { field1: 'test3' } }]);
+      await sendEvent1(castle.producer, [{ value: { field1: 'test3' }, key: null }]);
       expect(castle.isRunning()).toBe(true);
       await castle.stop();
       expect(castle.isRunning()).toBe(false);


### PR DESCRIPTION
Null keys can generally get you in a lot of trouble in kafka, and we should make their use explicit.

If a compacted topic encounters a null key, it will stop compacting, and there's nothing you can do about it except republishing in a new topic.

Should close #77
