### PR TITLE
Fix zero byte length messages

### DIFF
--- a/packages/avro-kafkajs/package.json
+++ b/packages/avro-kafkajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/avro-kafkajs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A wrapper around Kafkajs to transparently use Schema Registry for producing and consuming messages with avro schemas.",

--- a/packages/avro-kafkajs/src/avro.ts
+++ b/packages/avro-kafkajs/src/avro.ts
@@ -97,7 +97,7 @@ export const toAvroEachMessage = <T = unknown, KT = KafkaMessage['key']>(
         ? await schemaRegistry.decode<KT>(payload.message.key)
         : payload.message.key;
 
-    if (payload.message.value !== null) {
+    if (payload.message.value !== null && payload.message.value.length !== 0) {
       const { type, value } = await schemaRegistry.decodeWithType<T>(
         payload.message.value,
         readerSchema,

--- a/packages/castle/package.json
+++ b/packages/castle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/castle",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A kafka and avro based event listener",
@@ -41,7 +41,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-kafkajs": "^0.8.0",
+    "@ovotech/avro-kafkajs": "^0.8.1",
     "kafkajs": "^1.15.0",
     "lodash.chunk": "^4.2.0"
   }


### PR DESCRIPTION
When deleting messages in a kafka topic, perhaps manually or via tombstones kafkajs is returning zero byte length buffers, these to not evaluate to null, therefore we get a crash when trying to consume them. It looks a little something like this

```
{"level":"ERROR","timestamp":"2021-09-29T17:03:03.182Z","logger":"kafkajs","message":"[Runner] Error when calling eachMessage","topic":"couriers.courier_events","partition":0,"offset":"341523","stack":"RangeError [ERR_BUFFER_OUT_OF_BOUNDS]: Attempt to access memory outside buffer bounds\n 
```

This seems to solve the issue