### PR TITLE
Introduce flag to add TS Enum support as optional

### DIFF
--- a/packages/avro-ts-cli/README.md
+++ b/packages/avro-ts-cli/README.md
@@ -21,6 +21,7 @@ Options:
 - `-h, --help` - output usage information
 - `-e, --defaults-as-optional` - Fields with defaults as optional
 - `-O, --output-dir <outputDir>` - Directory to write typescript files to
+- `--with-typescript-enums` - Typescript Enum declarations instead of string union
 - `--logical-type <logicalType>` - Logical type, example: date=string (default: {})
 - `--logical-type-import <logicalType>` - Logical type import custom module, example: date=Decimal:decimal.js (default: {})
 - `--logical-type-import-all <logicalType>`- Logical type import custom module as \*, example: date=Decimal:decimal.js (default: {})

--- a/packages/avro-ts-cli/package.json
+++ b/packages/avro-ts-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts-cli",
   "description": "A cli to convert avro schemas into typescript interfaces",
-  "version": "3.4.11",
+  "version": "3.5.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "preset": "../../jest.json"
   },
   "dependencies": {
-    "@ovotech/avro-ts": "^6.0.9",
+    "@ovotech/avro-ts": "^6.1.0",
     "ansi-regex": "^5.0.0",
     "chalk": "^4.1.0",
     "commander": "^7.1.0"

--- a/packages/avro-ts-cli/src/convert.ts
+++ b/packages/avro-ts-cli/src/convert.ts
@@ -14,6 +14,7 @@ interface Options {
   logicalTypeImportDefault?: { [key: string]: { defaultAs: string; module: string } };
   outputDir?: string;
   defaultsAsOptional?: boolean;
+  withTypescriptEnums?: boolean;
 }
 
 export const convert = (logger: { log: (msg: string) => void } = console): commander.Command =>
@@ -22,6 +23,7 @@ export const convert = (logger: { log: (msg: string) => void } = console): comma
     .arguments('[input...]')
     .option('-O, --output-dir <outputDir>', 'Directory to write typescript files to')
     .option('-e, --defaults-as-optional', 'Fields with defaults as optional')
+    .option('--with-typescript-enums', 'Flag to use Typescript Enums for Avro Enums instead of string union')
     .option(
       '-l, --logical-type <logicalType>',
       'Logical type, example: date=string',
@@ -73,6 +75,7 @@ Example:
   avro-ts avro/*.avsc
   avro-ts avro/*.avsc --output-dir other/dir
   avro-ts avro/*.avsc --defaults-as-optional
+  avro-ts avro/*.avsc --with-typescript-enums
   avro-ts avro/*.avsc --logical-type date=string --logical-type datetime=string
   avro-ts avro/*.avsc --logical-type-import decimal=Decimal:decimal.js
   avro-ts avro/*.avsc --logical-type-import-default decimal=Decimal:decimal.js
@@ -89,6 +92,7 @@ Example:
           logicalTypeImportDefault,
           outputDir,
           defaultsAsOptional,
+          withTypescriptEnums,
         }: Options,
       ) => {
         if (files.length === 0) {
@@ -139,7 +143,7 @@ Example:
               {},
             );
 
-            const ts = toTypeScript(schema, { logicalTypes, external, defaultsAsOptional });
+            const ts = toTypeScript(schema, { logicalTypes, external, defaultsAsOptional, withTypescriptEnums });
             const outputFile = outputDir ? join(outputDir, `${basename(file)}.ts`) : `${file}.ts`;
             writeFileSync(outputFile, ts);
             const shortFile = file.replace(process.cwd(), '.');

--- a/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
+++ b/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
@@ -1997,3 +1997,92 @@ export namespace UkCoBoostpowerSupportKafkaMessages {
 }
 "
 `;
+
+exports[`Cli Should convert with typescript enums 1`] = `
+"Converting Avro to TypeScript
+
+Avro Schema                    | TypeScript File                  
+./test/avro/ComplexRecord.avsc | ./test/avro/ComplexRecord.avsc.ts
+"
+`;
+
+exports[`Cli Should convert with typescript enums 2`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export namespace ComExampleAvro {
+    export const FooName = \\"com.example.avro.Foo\\";
+    export interface Foo {
+        label: string;
+    }
+    export const EmailAddressName = \\"com.example.avro.EmailAddress\\";
+    /**
+     * Stores details about an email address that a user has associated with their account.
+     */
+    export interface EmailAddress {
+        /**
+         * The email address, e.g. \`foo@example.com\`
+         */
+        address: string;
+        /**
+         * true if the user has clicked the link in a confirmation email to this address.
+         *
+         * Default: false
+         */
+        verified: boolean;
+        /**
+         * Timestamp (milliseconds since epoch) when the email address was added to the account.
+         */
+        dateAdded: number;
+    }
+    export const StatusName = \\"com.example.avro.status\\";
+    /**
+     * * \`PENDING\`: the user has started authorizing, but not yet finished
+     * * \`ACTIVE\`: the token should work
+     * * \`DENIED\`: the user declined the authorization
+     * * \`EXPIRED\`: the token used to work, but now it doesn't
+     * * \`REVOKED\`: the user has explicitly revoked the token
+     */
+    export enum Status {
+        ACTIVE = \\"ACTIVE\\",
+        INACTIVE = \\"INACTIVE\\"
+    }
+    export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        mapField: {
+            [index: string]: ComExampleAvro.Foo;
+        };
+        /**
+         * All email addresses on the user's account
+         */
+        emailAddresses: ComExampleAvro.EmailAddress[];
+        /**
+         * Indicator of whether this authorization is currently active, or has been revoked
+         */
+        status: ComExampleAvro.Status;
+    }
+}
+"
+`;

--- a/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
+++ b/packages/avro-ts-cli/test/__snapshots__/cli.spec.ts.snap
@@ -41,13 +41,10 @@ export namespace ComExampleAvro {
     }
     export const StatusName = \\"com.example.avro.status\\";
     /**
-     * * \`PENDING\`: the user has started authorizing, but not yet finished
      * * \`ACTIVE\`: the token should work
-     * * \`DENIED\`: the user declined the authorization
-     * * \`EXPIRED\`: the token used to work, but now it doesn't
      * * \`REVOKED\`: the user has explicitly revoked the token
      */
-    export type Status = \\"ACTIVE\\" | \\"INACTIVE\\";
+    export type Status = \\"ACTIVE\\" | \\"REVOKED\\";
     export const UserName = \\"com.example.avro.User\\";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
@@ -407,13 +404,10 @@ export namespace ComExampleAvro {
     }
     export const StatusName = \\"com.example.avro.status\\";
     /**
-     * * \`PENDING\`: the user has started authorizing, but not yet finished
      * * \`ACTIVE\`: the token should work
-     * * \`DENIED\`: the user declined the authorization
-     * * \`EXPIRED\`: the token used to work, but now it doesn't
      * * \`REVOKED\`: the user has explicitly revoked the token
      */
-    export type Status = \\"ACTIVE\\" | \\"INACTIVE\\";
+    export type Status = \\"ACTIVE\\" | \\"REVOKED\\";
     export const UserName = \\"com.example.avro.User\\";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
@@ -773,13 +767,10 @@ export namespace ComExampleAvro {
     }
     export const StatusName = \\"com.example.avro.status\\";
     /**
-     * * \`PENDING\`: the user has started authorizing, but not yet finished
      * * \`ACTIVE\`: the token should work
-     * * \`DENIED\`: the user declined the authorization
-     * * \`EXPIRED\`: the token used to work, but now it doesn't
      * * \`REVOKED\`: the user has explicitly revoked the token
      */
-    export type Status = \\"ACTIVE\\" | \\"INACTIVE\\";
+    export type Status = \\"ACTIVE\\" | \\"REVOKED\\";
     export const UserName = \\"com.example.avro.User\\";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
@@ -1139,13 +1130,10 @@ export namespace ComExampleAvro {
     }
     export const StatusName = \\"com.example.avro.status\\";
     /**
-     * * \`PENDING\`: the user has started authorizing, but not yet finished
      * * \`ACTIVE\`: the token should work
-     * * \`DENIED\`: the user declined the authorization
-     * * \`EXPIRED\`: the token used to work, but now it doesn't
      * * \`REVOKED\`: the user has explicitly revoked the token
      */
-    export type Status = \\"ACTIVE\\" | \\"INACTIVE\\";
+    export type Status = \\"ACTIVE\\" | \\"REVOKED\\";
     export const UserName = \\"com.example.avro.User\\";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
@@ -1590,13 +1578,10 @@ export namespace ComExampleAvro {
     }
     export const StatusName = \\"com.example.avro.status\\";
     /**
-     * * \`PENDING\`: the user has started authorizing, but not yet finished
      * * \`ACTIVE\`: the token should work
-     * * \`DENIED\`: the user declined the authorization
-     * * \`EXPIRED\`: the token used to work, but now it doesn't
      * * \`REVOKED\`: the user has explicitly revoked the token
      */
-    export type Status = \\"ACTIVE\\" | \\"INACTIVE\\";
+    export type Status = \\"ACTIVE\\" | \\"REVOKED\\";
     export const UserName = \\"com.example.avro.User\\";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
@@ -1677,13 +1662,10 @@ export namespace ComExampleAvro {
     }
     export const StatusName = \\"com.example.avro.status\\";
     /**
-     * * \`PENDING\`: the user has started authorizing, but not yet finished
      * * \`ACTIVE\`: the token should work
-     * * \`DENIED\`: the user declined the authorization
-     * * \`EXPIRED\`: the token used to work, but now it doesn't
      * * \`REVOKED\`: the user has explicitly revoked the token
      */
-    export type Status = \\"ACTIVE\\" | \\"INACTIVE\\";
+    export type Status = \\"ACTIVE\\" | \\"REVOKED\\";
     export const UserName = \\"com.example.avro.User\\";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
@@ -2038,15 +2020,12 @@ export namespace ComExampleAvro {
     }
     export const StatusName = \\"com.example.avro.status\\";
     /**
-     * * \`PENDING\`: the user has started authorizing, but not yet finished
      * * \`ACTIVE\`: the token should work
-     * * \`DENIED\`: the user declined the authorization
-     * * \`EXPIRED\`: the token used to work, but now it doesn't
      * * \`REVOKED\`: the user has explicitly revoked the token
      */
     export enum Status {
         ACTIVE = \\"ACTIVE\\",
-        INACTIVE = \\"INACTIVE\\"
+        REVOKED = \\"REVOKED\\"
     }
     export const UserName = \\"com.example.avro.User\\";
     /**

--- a/packages/avro-ts-cli/test/avro/ComplexRecord.avsc
+++ b/packages/avro-ts-cli/test/avro/ComplexRecord.avsc
@@ -74,8 +74,8 @@
       "type": {
         "type": "enum",
         "name": "status",
-        "doc": "* `PENDING`: the user has started authorizing, but not yet finished\n* `ACTIVE`: the token should work\n* `DENIED`: the user declined the authorization\n* `EXPIRED`: the token used to work, but now it doesn't\n* `REVOKED`: the user has explicitly revoked the token",
-        "symbols": ["ACTIVE", "INACTIVE"]
+        "doc": "* `ACTIVE`: the token should work\n* `REVOKED`: the user has explicitly revoked the token",
+        "symbols": ["ACTIVE", "REVOKED"]
       }
     }
   ]

--- a/packages/avro-ts-cli/test/avro/ComplexRecord.avsc.ts
+++ b/packages/avro-ts-cli/test/avro/ComplexRecord.avsc.ts
@@ -29,13 +29,10 @@ export namespace ComExampleAvro {
     }
     export const StatusName = "com.example.avro.status";
     /**
-     * * `PENDING`: the user has started authorizing, but not yet finished
      * * `ACTIVE`: the token should work
-     * * `DENIED`: the user declined the authorization
-     * * `EXPIRED`: the token used to work, but now it doesn't
      * * `REVOKED`: the user has explicitly revoked the token
      */
-    export type Status = "ACTIVE" | "INACTIVE";
+    export type Status = "ACTIVE" | "REVOKED";
     export const UserName = "com.example.avro.User";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.

--- a/packages/avro-ts-cli/test/cli.spec.ts
+++ b/packages/avro-ts-cli/test/cli.spec.ts
@@ -48,6 +48,16 @@ describe('Cli', () => {
     expect(file).toMatchSnapshot();
   });
 
+  it('Should convert with typescript enums', async () => {
+    const input = `cmd avro-ts ${join(avroDir, 'ComplexRecord.avsc')} --with-typescript-enums`;
+    convert(logger).parse(input.split(' '));
+
+    const file = readFileSync(join(avroDir, 'ComplexRecord.avsc.ts'), 'utf8');
+
+    expect(logger.std).toMatchSnapshot();
+    expect(file).toMatchSnapshot();
+  });
+
   it('Should convert multiple files', async () => {
     const input1 = join(avroDir, 'ComplexRecord.avsc');
     const input2 = join(avroDir, 'ComplexUnionLogicalTypes.avsc');

--- a/packages/avro-ts/README.md
+++ b/packages/avro-ts/README.md
@@ -252,6 +252,34 @@ const ts = toTypeScript(avro, { defaultsAsOptional: true });
 console.log(ts);
 ```
 
+## Typescript Enums
+
+By default AVRO enums are converted to a string union. If you prefer to use Typescript enums instead, you can use withTypescriptEnums option.
+
+> [examples/with-typescript-enums.ts](examples/with-typescript-enums.ts)
+
+```typescript
+import { toTypeScript } from '@ovotech/avro-ts';
+import { Schema } from 'avsc';
+
+const avro: Schema = {
+  type: 'record',
+  name: 'User',
+  fields: [
+    { name: 'id', type: 'int' },
+    {
+      "name": "status",
+      "type": { "type": "enum", "name": "Status", "symbols": ["Active", "Inactive"] },
+      "doc": "The status of the user account"
+    },
+  ],
+};
+
+const ts = toTypeScript(avro, { withTypescriptEnums: true });
+
+console.log(ts);
+```
+
 ## External references
 
 AvroTs supports external references to schemas in other files. In order to do that you'll need to convert the external schemas first, and then pass them as "external" in the initial context. This can be used as a building blocks to process multiple schemas at once.

--- a/packages/avro-ts/examples/with-typescript-enums.ts
+++ b/packages/avro-ts/examples/with-typescript-enums.ts
@@ -1,0 +1,21 @@
+import { toTypeScript } from '@ovotech/avro-ts';
+import { Schema } from 'avsc';
+
+const avro: Schema = {
+  type: 'record',
+  name: 'User',
+  fields: [
+    { name: 'id', type: 'int' },
+    {
+      "name": "status",
+      "type": { "type": "enum", "name": "Status", "symbols": ["Active", "Inactive"] },
+      "doc": "The status of the user account"
+    },
+  ],
+};
+
+const ts = toTypeScript(avro, { withTypescriptEnums: true });
+
+console.log(ts);
+
+

--- a/packages/avro-ts/examples/with-typescript-enums.ts
+++ b/packages/avro-ts/examples/with-typescript-enums.ts
@@ -17,5 +17,3 @@ const avro: Schema = {
 const ts = toTypeScript(avro, { withTypescriptEnums: true });
 
 console.log(ts);
-
-

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ovotech/avro-ts",
   "description": "Convert avro schemas into typescript interfaces",
-  "version": "6.0.8",
+  "version": "6.1.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.28",
-    "avsc": "^5.5.6",
+    "avsc": "^5.7.5",
     "eslint-config-prettier": "^7.2.0",
     "jest": "^26.6.3",
     "moment": "^2.29.1",

--- a/packages/avro-ts/src/helpers.ts
+++ b/packages/avro-ts/src/helpers.ts
@@ -25,7 +25,7 @@ export const nameParts = (fullName: string): [string] | [string, string] => {
 };
 
 export const namedType = (
-  type: ts.InterfaceDeclaration | ts.TypeAliasDeclaration,
+  type: ts.InterfaceDeclaration | ts.TypeAliasDeclaration | ts.EnumDeclaration,
   context: Context,
   schema: avroSchema.RecordType | avroSchema.EnumType,
   namespace?: string,

--- a/packages/avro-ts/src/types.ts
+++ b/packages/avro-ts/src/types.ts
@@ -13,6 +13,7 @@ export interface Context extends DocumentContext {
   refs?: { [key: string]: Schema };
   external?: { [file: string]: { [key: string]: Schema } };
   defaultsAsOptional?: boolean;
+  withTypescriptEnums?: boolean;
 }
 
 export type Convert<TSchema = Schema, TType = ts.TypeNode> = (

--- a/packages/avro-ts/src/types/enum.ts
+++ b/packages/avro-ts/src/types/enum.ts
@@ -1,20 +1,36 @@
 import { schema, Schema } from 'avsc';
 import { Convert } from '../types';
-import { Type } from '@ovotech/ts-compose';
+import { Node, Type } from '@ovotech/ts-compose';
 import { convertName, namedType, firstUpperCase } from '../helpers';
+import { withDefault } from './record';
 
-export const isEnumType = (type: Schema): type is schema.EnumType =>
+interface EnumWithDefault extends schema.EnumType {
+  default?: string,
+}
+
+export const isEnumType = (type: Schema): type is EnumWithDefault =>
   typeof type === 'object' && 'type' in type && type.type === 'enum';
 
-export const convertEnumType: Convert<schema.EnumType> = (context, schema) => {
+export const convertEnumType: Convert<EnumWithDefault> = (context, schema) => {
   const namespace = schema.namespace ?? context.namespace;
+  let type;
 
-  const type = Type.Alias({
-    name: convertName(firstUpperCase(schema.name)),
-    type: Type.Union(schema.symbols.map((symbol) => Type.Literal(symbol))),
-    isExport: true,
-    jsDoc: schema.doc,
-  });
+  if (context.withTypescriptEnums === true) {
+    type = Node.Enum({
+      name: convertName(firstUpperCase(schema.name)),
+      members: schema.symbols.map(val => Node.EnumMember({ name: val, value: val })),
+      isExport: true,
+      jsDoc: schema.default ? withDefault(schema.default, schema.doc) : schema.doc,
+    });
+  } else {
+    type = Type.Alias({
+      name: convertName(firstUpperCase(schema.name)),
+      type: Type.Union(schema.symbols.map((symbol) => Type.Literal(symbol))),
+      isExport: true,
+      jsDoc: schema.doc,
+    });
+  }
+
 
   return namedType(type, context, schema, namespace);
 };

--- a/packages/avro-ts/src/types/enum.ts
+++ b/packages/avro-ts/src/types/enum.ts
@@ -4,14 +4,10 @@ import { Node, Type } from '@ovotech/ts-compose';
 import { convertName, namedType, firstUpperCase } from '../helpers';
 import { withDefault } from './record';
 
-interface EnumWithDefault extends schema.EnumType {
-  default?: string,
-}
-
-export const isEnumType = (type: Schema): type is EnumWithDefault =>
+export const isEnumType = (type: Schema): type is schema.EnumType =>
   typeof type === 'object' && 'type' in type && type.type === 'enum';
 
-export const convertEnumType: Convert<EnumWithDefault> = (context, schema) => {
+export const convertEnumType: Convert<schema.EnumType> = (context, schema) => {
   const namespace = schema.namespace ?? context.namespace;
   let type;
 

--- a/packages/avro-ts/src/types/enum.ts
+++ b/packages/avro-ts/src/types/enum.ts
@@ -9,24 +9,20 @@ export const isEnumType = (type: Schema): type is schema.EnumType =>
 
 export const convertEnumType: Convert<schema.EnumType> = (context, schema) => {
   const namespace = schema.namespace ?? context.namespace;
-  let type;
-
-  if (context.withTypescriptEnums === true) {
-    type = Node.Enum({
+  const type = context.withTypescriptEnums === true ?
+    Node.Enum({
       name: convertName(firstUpperCase(schema.name)),
       members: schema.symbols.map(val => Node.EnumMember({ name: val, value: val })),
       isExport: true,
       jsDoc: schema.default ? withDefault(schema.default, schema.doc) : schema.doc,
-    });
-  } else {
-    type = Type.Alias({
+    })
+    :
+    Type.Alias({
       name: convertName(firstUpperCase(schema.name)),
       type: Type.Union(schema.symbols.map((symbol) => Type.Literal(symbol))),
       isExport: true,
       jsDoc: schema.doc,
     });
-  }
-
 
   return namedType(type, context, schema, namespace);
 };

--- a/packages/avro-ts/test/__snapshots__/external-references.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/external-references.spec.ts.snap
@@ -1,5 +1,124 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Avro ts test Should convert %s successfully using Typescript Enums: Address.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type Address = MyNamespaceData.Address;
+
+export namespace MyNamespaceData {
+    export const AddressName = \\"my.namespace.data.Address\\";
+    export interface Address {
+        street: string;
+        zipcode: string;
+        country: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using Typescript Enums: AvroJobStatus.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type AvroJobStatus = ComZenatonJobManagerData.AvroJobStatus;
+
+export namespace ComZenatonJobManagerData {
+    export const AvroJobStatusName = \\"com.zenaton.jobManager.data.AvroJobStatus\\";
+    export enum AvroJobStatus {
+        RUNNING_OK = \\"RUNNING_OK\\",
+        RUNNING_WARNING = \\"RUNNING_WARNING\\",
+        RUNNING_ERROR = \\"RUNNING_ERROR\\",
+        TERMINATED_COMPLETED = \\"TERMINATED_COMPLETED\\",
+        TERMINATED_CANCELED = \\"TERMINATED_CANCELED\\"
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using Typescript Enums: AvroJobStatusUpdated.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { ComZenatonJobManagerData as ComZenatonJobManagerDataAvroJobStatus } from \\"./AvroJobStatus.avsc.external\\";
+
+export type AvroJobStatusUpdated = ComZenatonJobManagerMessages.AvroJobStatusUpdated;
+
+export namespace ComZenatonJobManagerMessages {
+    export const AvroJobStatusUpdatedName = \\"com.zenaton.jobManager.messages.AvroJobStatusUpdated\\";
+    export interface AvroJobStatusUpdated {
+        jobId: string;
+        jobName: string;
+        oldStatus: null | ComZenatonJobManagerDataAvroJobStatus.AvroJobStatus;
+        newStatus: ComZenatonJobManagerDataAvroJobStatus.AvroJobStatus;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using Typescript Enums: CreateUser.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { MyNamespaceData as MyNamespaceDataAddress } from \\"./Address.avsc.external\\";
+
+export type CreateUser = MyNamespaceMessages.CreateUser;
+
+export namespace MyNamespaceMessages {
+    export const CreateUserName = \\"my.namespace.messages.CreateUser\\";
+    export interface CreateUser {
+        userId: string;
+        name: string;
+        address: MyNamespaceDataAddress.Address;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using Typescript Enums: Message.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { MyNamespaceMessages as MyNamespaceMessagesCreateUser } from \\"./CreateUser.avsc.external\\";
+
+import { MyNamespaceMessages as MyNamespaceMessagesUpdateAddress } from \\"./UpdateAddress.avsc.external\\";
+
+export type Message = MyNamespace.Message;
+
+export namespace MyNamespace {
+    export const MessageTypeName = \\"my.namespace.MessageType\\";
+    export enum MessageType {
+        CreateUser = \\"CreateUser\\",
+        UpdateAddress = \\"UpdateAddress\\"
+    }
+    export const MessageName = \\"my.namespace.Message\\";
+    export interface Message {
+        type: MyNamespace.MessageType;
+        /**
+         * Default: null
+         */
+        CreateUser: null | MyNamespaceMessagesCreateUser.CreateUser;
+        /**
+         * Default: null
+         */
+        UpdateAddress: null | MyNamespaceMessagesUpdateAddress.UpdateAddress;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using Typescript Enums: UpdateAddress.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { MyNamespaceData as MyNamespaceDataAddress } from \\"./Address.avsc.external\\";
+
+export type UpdateAddress = MyNamespaceMessages.UpdateAddress;
+
+export namespace MyNamespaceMessages {
+    export const UpdateAddressName = \\"my.namespace.messages.UpdateAddress\\";
+    export interface UpdateAddress {
+        userId: string;
+        address: MyNamespaceDataAddress.Address;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert %s successfully: Address.avsc 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 

--- a/packages/avro-ts/test/__snapshots__/integration.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/integration.spec.ts.snap
@@ -115,6 +115,127 @@ export namespace UkCoBoostpowerSupportKafkaMessages {
 "
 `;
 
+exports[`Avro ts test Should convert BalanceAdjustment.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Moment } from \\"moment\\";
+
+export type BalanceAdjustment = UkCoBoostpowerSupportKafkaMessages.BalanceAdjustment;
+
+export namespace ComOvoenergyKafkaCommonEvent {
+    export const ConfigName = \\"com.ovoenergy.kafka.common.event.Config\\";
+    export interface Config {
+        tokenId: string;
+    }
+    export const ConfigExtendedName = \\"com.ovoenergy.kafka.common.event.ConfigExtended\\";
+    export interface ConfigExtended {
+        tokenId: string;
+        extensionId: string;
+    }
+    export const EventMetadataName = \\"com.ovoenergy.kafka.common.event.EventMetadata\\";
+    /**
+     * Metadata, to be used in each event class
+     */
+    export interface EventMetadata {
+        /**
+         * A globally unique ID for this Kafka message
+         */
+        eventId: string;
+        /**
+         * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+         */
+        traceToken: string;
+        /**
+         * A timestamp for when the event was created (in epoch millis)
+         */
+        createdAt: Moment;
+        config: {
+            \\"com.ovoenergy.kafka.common.event.Config\\": ComOvoenergyKafkaCommonEvent.Config;
+            \\"com.ovoenergy.kafka.common.event.ConfigExtended\\"?: never;
+        } | {
+            \\"com.ovoenergy.kafka.common.event.Config\\"?: never;
+            \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": ComOvoenergyKafkaCommonEvent.ConfigExtended;
+        };
+    }
+}
+
+export namespace UkCoBoostpowerSupportKafkaMessages {
+    export const FuelName = \\"uk.co.boostpower.support.kafka.messages.Fuel\\";
+    export enum Fuel {
+        Gas = \\"Gas\\",
+        Electricity = \\"Electricity\\"
+    }
+    export const BalanceAdjustmentRequestName = \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\";
+    /**
+     * Balance Adjustment request has been sent
+     */
+    export interface BalanceAdjustmentRequest {
+        /**
+         * A unique balance adjustment job id. Will correspond with the jobId of BalanceAdjustmentResponse
+         */
+        jobId: string;
+        /**
+         * Unique identifier for the customer. Gentrack Account ID. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * Meter Serial Number of the meter having its balance adjusted
+         */
+        msn: string;
+        /**
+         * A Meter Point Administration Number (Electricity) or Meter Point Reference Number (Gas). It is expected that the specified meter supplies this Supply Point.
+         */
+        mpxn: string;
+        /**
+         * Type of fuel of the meter
+         */
+        fuel: UkCoBoostpowerSupportKafkaMessages.Fuel;
+        /**
+         * The amount the balance was adjusted with, in thousands of a penny
+         */
+        amount: number;
+    }
+    export const StatusName = \\"uk.co.boostpower.support.kafka.messages.Status\\";
+    export enum Status {
+        Error = \\"Error\\",
+        Success = \\"Success\\"
+    }
+    export const BalanceAdjustmentResponseName = \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\";
+    /**
+     * Balance Adjustment Completion
+     */
+    export interface BalanceAdjustmentResponse {
+        /**
+         * A unique adjustment job id. Will correspond with the jobId S2BalanceAdjustmentRequest
+         */
+        jobId: string;
+        /**
+         * The status of the balance adjustment when its completed
+         */
+        status: UkCoBoostpowerSupportKafkaMessages.Status;
+        /**
+         * The resulting the balance after the adjustemt, in thousands of a penny
+         */
+        balance: number;
+    }
+    export const BalanceAdjustmentName = \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustment\\";
+    /**
+     * A balance adjustment request and response events
+     */
+    export interface BalanceAdjustment {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        event: {
+            \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": UkCoBoostpowerSupportKafkaMessages.BalanceAdjustmentRequest;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": UkCoBoostpowerSupportKafkaMessages.BalanceAdjustmentResponse;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert BalanceAdjustment.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -231,6 +352,237 @@ export namespace UkCoBoostpowerSupportKafkaMessages {
 `;
 
 exports[`Avro ts test Should convert CommUpdateType.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Moment } from \\"moment\\";
+
+export type CommunicationUpdate = ComExampleKafkaComms.CommunicationUpdate;
+
+export namespace ComExampleKafkaCommonEvent {
+    export const EventMetadataName = \\"com.example.kafka.common.event.EventMetadata\\";
+    export interface EventMetadata {
+        eventId: string;
+        traceToken: string;
+        createdAt: Moment;
+    }
+}
+
+export namespace ComExampleKafkaComms {
+    export const TemplateManifestName = \\"com.example.kafka.comms.TemplateManifest\\";
+    export interface TemplateManifest {
+        id: string;
+        version: string;
+    }
+    export const TemplateName = \\"com.example.kafka.comms.Template\\";
+    export interface Template {
+        manifest: ComExampleKafkaComms.TemplateManifest;
+        name: string;
+        commType: string;
+    }
+    export const PostalAddressName = \\"com.example.kafka.comms.PostalAddress\\";
+    export interface PostalAddress {
+        /**
+         * Default: null
+         */
+        contactName: null | string;
+        /**
+         * Default: null
+         */
+        company: null | string;
+        line1: string;
+        /**
+         * Default: null
+         */
+        line2: null | string;
+        town: string;
+        /**
+         * Default: null
+         */
+        county: null | string;
+        postcode: string;
+        /**
+         * Default: null
+         */
+        country: null | string;
+    }
+    export const FailureName = \\"com.example.kafka.comms.Failure\\";
+    export interface Failure {
+        at: Moment;
+        code: string;
+        reason: string;
+    }
+    export const AttachmentName = \\"com.example.kafka.comms.Attachment\\";
+    export interface Attachment {
+        uri: string;
+        fileName: string;
+    }
+    export const SpecialRequirementsName = \\"com.example.kafka.comms.SpecialRequirements\\";
+    export interface SpecialRequirements {
+        preferences: string[];
+    }
+    export const CommunicationName = \\"com.example.kafka.comms.Communication\\";
+    export interface Communication {
+        id: string;
+        traceToken: string;
+        brand: string;
+        template: ComExampleKafkaComms.Template;
+        status: string;
+        description: string;
+        source: string;
+        isCanary: boolean;
+        triggeredAt: Moment;
+        /**
+         * Default: null
+         */
+        scheduledAt: null | Moment;
+        /**
+         * Default: null
+         */
+        orchestratedAt: null | Moment;
+        /**
+         * Default: null
+         */
+        composedAt: null | Moment;
+        /**
+         * Default: null
+         */
+        issuedForDeliveryAt: null | Moment;
+        /**
+         * Default: null
+         */
+        deliveredAt: null | Moment;
+        /**
+         * Default: null
+         */
+        expireAt: null | Moment;
+        deliverTo: {
+            \\"DeliverTo.Customer\\": DeliverTo.Customer;
+            \\"DeliverTo.ContactDetails\\"?: never;
+        } | {
+            \\"DeliverTo.Customer\\"?: never;
+            \\"DeliverTo.ContactDetails\\": DeliverTo.ContactDetails;
+        };
+        /**
+         * Default: null
+         */
+        recipient: null | {
+            \\"com.example.kafka.comms.Recipient.Email\\": ComExampleKafkaCommsRecipient.Email;
+            \\"com.example.kafka.comms.Recipient.Phone\\"?: never;
+            \\"com.example.kafka.comms.Recipient.Postal\\"?: never;
+        } | {
+            \\"com.example.kafka.comms.Recipient.Email\\"?: never;
+            \\"com.example.kafka.comms.Recipient.Phone\\": ComExampleKafkaCommsRecipient.Phone;
+            \\"com.example.kafka.comms.Recipient.Postal\\"?: never;
+        } | {
+            \\"com.example.kafka.comms.Recipient.Email\\"?: never;
+            \\"com.example.kafka.comms.Recipient.Phone\\"?: never;
+            \\"com.example.kafka.comms.Recipient.Postal\\": ComExampleKafkaCommsRecipient.Postal;
+        };
+        /**
+         * Default: null
+         */
+        channel: null | string;
+        /**
+         * Default: null
+         */
+        failure: null | ComExampleKafkaComms.Failure;
+        /**
+         * Default: null
+         */
+        content: null | {
+            \\"com.example.kafka.comms.Content.Email\\": ComExampleKafkaCommsContent.Email;
+            \\"com.example.kafka.comms.Content.Sms\\"?: never;
+            \\"com.example.kafka.comms.Content.Print\\"?: never;
+        } | {
+            \\"com.example.kafka.comms.Content.Email\\"?: never;
+            \\"com.example.kafka.comms.Content.Sms\\": ComExampleKafkaCommsContent.Sms;
+            \\"com.example.kafka.comms.Content.Print\\"?: never;
+        } | {
+            \\"com.example.kafka.comms.Content.Email\\"?: never;
+            \\"com.example.kafka.comms.Content.Sms\\"?: never;
+            \\"com.example.kafka.comms.Content.Print\\": ComExampleKafkaCommsContent.Print;
+        };
+        /**
+         * Default: []
+         */
+        attachments: ComExampleKafkaComms.Attachment[];
+        /**
+         * Default: null
+         */
+        specialRequirements: null | ComExampleKafkaComms.SpecialRequirements;
+    }
+    export const CommunicationUpdateName = \\"com.example.kafka.comms.CommunicationUpdate\\";
+    export interface CommunicationUpdate {
+        metadata: ComExampleKafkaCommonEvent.EventMetadata;
+        communication: ComExampleKafkaComms.Communication;
+    }
+}
+
+export namespace DeliverTo {
+    export const ContactDetailsName = \\"DeliverTo.ContactDetails\\";
+    export interface ContactDetails {
+        /**
+         * Default: null
+         */
+        emailAddress: null | string;
+        /**
+         * Default: null
+         */
+        phoneNumber: null | string;
+        /**
+         * Default: null
+         */
+        postalAddress: null | ComExampleKafkaComms.PostalAddress;
+    }
+    export const CustomerName = \\"DeliverTo.Customer\\";
+    export interface Customer {
+        profileId: string;
+        /**
+         * Default: null
+         */
+        contactDetails: null | DeliverTo.ContactDetails;
+    }
+}
+
+export namespace ComExampleKafkaCommsRecipient {
+    export const EmailName = \\"com.example.kafka.comms.Recipient.Email\\";
+    export interface Email {
+        emailAddress: string;
+    }
+    export const PhoneName = \\"com.example.kafka.comms.Recipient.Phone\\";
+    export interface Phone {
+        phoneNumber: string;
+    }
+    export const PostalName = \\"com.example.kafka.comms.Recipient.Postal\\";
+    export interface Postal {
+        postalAddress: ComExampleKafkaComms.PostalAddress;
+    }
+}
+
+export namespace ComExampleKafkaCommsContent {
+    export const EmailName = \\"com.example.kafka.comms.Content.Email\\";
+    export interface Email {
+        sender: string;
+        subject: string;
+        body: string;
+        /**
+         * Default: null
+         */
+        textBody: null | string;
+    }
+    export const SmsName = \\"com.example.kafka.comms.Content.Sms\\";
+    export interface Sms {
+        body: string;
+    }
+    export const PrintName = \\"com.example.kafka.comms.Content.Print\\";
+    export interface Print {
+        body: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert CommUpdateType.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 import { Moment } from \\"moment\\";
@@ -763,6 +1115,93 @@ export namespace ComExampleAvro {
         emailAddresses: ComExampleAvro.EmailAddress[];
         /**
          * Indicator of whether this authorization is currently active, or has been revoked
+         *
+         * Default: \\"INACTIVE\\"
+         */
+        status: ComExampleAvro.Status;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert ComplexRecord.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export namespace ComExampleAvro {
+    export const FooName = \\"com.example.avro.Foo\\";
+    export interface Foo {
+        label: string;
+    }
+    export const EmailAddressName = \\"com.example.avro.EmailAddress\\";
+    /**
+     * Stores details about an email address that a user has associated with their account.
+     */
+    export interface EmailAddress {
+        /**
+         * The email address, e.g. \`foo@example.com\`
+         */
+        address: string;
+        /**
+         * true if the user has clicked the link in a confirmation email to this address.
+         *
+         * Default: false
+         */
+        verified: boolean;
+        /**
+         * Timestamp (milliseconds since epoch) when the email address was added to the account.
+         */
+        dateAdded: number;
+    }
+    export const StatusName = \\"com.example.avro.status\\";
+    /**
+     * * \`PENDING\`: the user has started authorizing, but not yet finished
+     * * \`ACTIVE\`: the token should work
+     * * \`DENIED\`: the user declined the authorization
+     * * \`EXPIRED\`: the token used to work, but now it doesn't
+     * * \`REVOKED\`: the user has explicitly revoked the token
+     *
+     * Default: \\"ACTIVE\\"
+     */
+    export enum Status {
+        ACTIVE = \\"ACTIVE\\",
+        INACTIVE = \\"INACTIVE\\"
+    }
+    export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        mapField: {
+            [index: string]: ComExampleAvro.Foo;
+        };
+        /**
+         * All email addresses on the user's account
+         */
+        emailAddresses: ComExampleAvro.EmailAddress[];
+        /**
+         * Indicator of whether this authorization is currently active, or has been revoked
+         *
+         * Default: \\"INACTIVE\\"
          */
         status: ComExampleAvro.Status;
     }
@@ -841,14 +1280,289 @@ export namespace ComExampleAvro {
         emailAddresses: ComExampleAvro.EmailAddress[];
         /**
          * Indicator of whether this authorization is currently active, or has been revoked
+         *
+         * Default: \\"INACTIVE\\"
          */
-        status: ComExampleAvro.Status;
+        status?: ComExampleAvro.Status;
     }
 }
 "
 `;
 
 exports[`Avro ts test Should convert ComplexUnionLogicalTypes.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Moment } from \\"moment\\";
+
+export type AccountMigrationEvent = UkCoBoostpowerSupportKafkaMessages.AccountMigrationEvent;
+
+export namespace ComOvoenergyKafkaCommonEvent {
+    export const EventMetadataName = \\"com.ovoenergy.kafka.common.event.EventMetadata\\";
+    /**
+     * Metadata, to be used in each event class
+     */
+    export interface EventMetadata {
+        /**
+         * A globally unique ID for this Kafka message
+         */
+        eventId: string;
+        /**
+         * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+         */
+        traceToken: string;
+        /**
+         * A timestamp for when the event was created (in epoch millis)
+         */
+        createdAt: Moment;
+    }
+}
+
+export namespace UkCoBoostpowerSupportKafkaMessages {
+    export const AccountMigrationCancelledEventName = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\";
+    /**
+     * Triggered by Migration Service. Before T2 signals that a siemens account migration has been cancelled. Migration is about to be restarted for the same account that means a new AccountMigrationScheduledEvent with a new flow id will be sent.Consumers should not react on this in normal case.
+     */
+    export interface AccountMigrationCancelledEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The unique national reference for Meter Point Administration Number
+         */
+        mpan: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration was cancelled (in epoch millis)
+         */
+        cancelledAt: Moment;
+    }
+    export const AccountMigrationCompletedEventName = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\";
+    /**
+     * Triggered by SMILE. After SMILE processed the AccountMigrationValidatedEvent and switched over to Billy from Siemens they trigger this event to inform consumers like BIT CSA portal and Salesforce to do the necessary steps for the switchover
+     */
+    export interface AccountMigrationCompletedEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration was completed (in epoch millis)
+         */
+        completedAt: Moment;
+    }
+    export const AccountMigrationRollBackInitiatedEventName = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\";
+    /**
+     * Triggered by Migration Service. After T2 it signals that a siemens account migration roll back was initiated. SMILE should change the data master system for the account from Billy to Siemens and inform other system about the result.
+     */
+    export interface AccountMigrationRollBackInitiatedEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration rollback was initiated (in epoch millis)
+         */
+        rollBackInitiatedAt: Moment;
+    }
+    export const AccountMigrationRolledBackEventName = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\";
+    /**
+     * Triggered by SMILE. As the response to the AccountMigrationRollBackInitiatedEvent, SMILE indicates that mastering system for account data has been restored to be Siemens.As an action to this Billy, BIT CSA portal and Salesforce can do the necessary steps to clean up internal data and switch over to use Siemens data.
+     */
+    export interface AccountMigrationRolledBackEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration was rolled back (in epoch millis)
+         */
+        rolledBackAt: Moment;
+    }
+    export const AccountMigrationScheduledEventName = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\";
+    /**
+     * Triggered by Migration Service. At T-2 it signals that a siemens account migration has been scheduled for T0 (effectiveEnrollmentDate).Consumers should do the necessary steps like removing primary card functionality in PAYG account service. If consumers see a new AccountMigrationScheduledEvent with a new flow id then they have to update their internal state with the new flow id since every subsequent message in the migration flow will use the same id
+     */
+    export interface AccountMigrationScheduledEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The unique national reference for Meter Point Administration Number
+         */
+        mpan: string;
+        /**
+         * The date when the customer came on supply with Boost (in epoch days)
+         */
+        supplyStartDate: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration was scheduled (in epoch millis)
+         */
+        scheduledAt: Moment;
+    }
+    export const AccountMigrationValidatedEventName = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\";
+    /**
+     * Triggered by Balance Service. At T2 it signals that a siemens balance and transaction history was migrated to the new balance platform and the validation was successful. Billy is ready to be the source for balance and transaction history data. SMILE should change the data master system for the account from Siemens to Billy and inform other system about the result
+     */
+    export interface AccountMigrationValidatedEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migrated balance and transactions were validated (in epoch millis)
+         */
+        validatedAt: Moment;
+    }
+    export const BalanceRetrievedMigrationEventName = \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\";
+    /**
+     * Triggered by Migration Service. At T1 signals that a siemens balance and transaction history is available for Billy. Contains details.
+     */
+    export interface BalanceRetrievedMigrationEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The unique national reference for Meter Point Administration Number
+         */
+        mpan: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the balance and transaction history was fetched (in epoch millis)
+         */
+        retrievedAt: Moment;
+    }
+    export const AccountMigrationEventName = \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\";
+    /**
+     * Account migration related events. It describes several flows: 1. Happy path: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationValidatedEvent -> AccountMigrationCompletedEvent 2. Cancel where the migration is about the be restarted: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationCancelledEvent -> Start from the beginning, AccountMigrationScheduledEvent -> AccountMigrationCancelledEvent -> Start from the beginning 3. Rollback: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationValidatedEvent -> AccountMigrationCompletedEvent -> AccountMigrationRollBackInitiatedEvent -> AccountMigrationRolledBackEvent -> Start from the beginning AccountMigrationScheduledEvent generates a flow id which is used in every subsequent migration message to be grouped together
+     */
+    export interface AccountMigrationEvent {
+        event: {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationCancelledEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationCompletedEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationRollBackInitiatedEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationRolledBackEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationScheduledEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationValidatedEvent;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": UkCoBoostpowerSupportKafkaMessages.BalanceRetrievedMigrationEvent;
+        };
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert ComplexUnionLogicalTypes.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 import { Moment } from \\"moment\\";
@@ -1401,6 +2115,16 @@ export type ComExampleAvroMyEnum = \\"ACTIVE\\" | \\"INACTIVE\\";
 "
 `;
 
+exports[`Avro ts test Should convert EnumWithFullName.avsc successfully using Typescript Enums 1`] = `
+"export type AvroType = ComExampleAvroMyEnum;
+
+export enum ComExampleAvroMyEnum {
+    ACTIVE = \\"ACTIVE\\",
+    INACTIVE = \\"INACTIVE\\"
+}
+"
+`;
+
 exports[`Avro ts test Should convert EnumWithFullName.avsc successfully with default as optional 1`] = `
 "export type AvroType = ComExampleAvroMyEnum;
 
@@ -1416,6 +2140,25 @@ export type EpicFailure = Namespace.EpicFailure;
 export namespace Namespace {
     export const ErrorCodeName = \\"namespace.ErrorCode\\";
     export type ErrorCode = \\"ERROR\\";
+    export const EpicFailureName = \\"namespace.EpicFailure\\";
+    export interface EpicFailure {
+        code: Namespace.ErrorCode;
+        message: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert EpicError.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type EpicFailure = Namespace.EpicFailure;
+
+export namespace Namespace {
+    export const ErrorCodeName = \\"namespace.ErrorCode\\";
+    export enum ErrorCode {
+        ERROR = \\"ERROR\\"
+    }
     export const EpicFailureName = \\"namespace.EpicFailure\\";
     export interface EpicFailure {
         code: Namespace.ErrorCode;
@@ -1443,6 +2186,135 @@ export namespace Namespace {
 `;
 
 exports[`Avro ts test Should convert M03.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type M03 = MbrSplitM03.M03;
+
+export namespace MbrSplitM03M03 {
+    export const ItemsName = \\"mbr.split.m03.m03.Items\\";
+    export interface Items {
+        SHIPPER_REFERENCE: string;
+        SEND_REASON_CODE: string;
+        ACTUAL_READ_DATE: string;
+        METER_SERIAL_NUMBER: string;
+        METER_POINT_REFERENCE: string;
+        PRIME_METER_POINT_REFERENCE: string;
+        BILLING_INDICATOR: string;
+        READ_SEQUENCE: string;
+        READ_REASON_CODE: string;
+        READ_TYPE: string;
+        METER_READING: string;
+        NUMBER_OF_DIALS_OR_DIGITS: string;
+        CORRECTOR_UNCORRECTED_READING: string;
+        NUMBER_OF_DIALS_UNCORRECTED: string;
+        CORRECTOR_CORRECTED_READING: string;
+        NUMBER_OF_DIALS_CORRECTED: string;
+        OVERRIDE_VOLUME: string;
+        OVERRIDE_VOLUME_UNITS: string;
+        OVERRIDE_REASON: string;
+        BYPASS_STATUS: string;
+        COLLAR_STATUS: string;
+        CAPPED_STATUS: string;
+        CORRECTOR_STATUS: string;
+        NOTE_CODE_1: string;
+        NOTE_CODE_2: string;
+        NOTE_CODE_3: string;
+        NOTE_CODE_4: string;
+        NOTE_CODE_5: string;
+        METRIC_IMPERIAL_INDICATOR: string;
+        METER_CORRECTION_FACTOR: string;
+        CORRECTOR_CORRECTION_FACTOR: string;
+        READING_FACTOR: string;
+        METER_THROUGH_ZEROS_COUNT: string;
+        CORRECTOR_THROUGH_ZEROS_COUNT: string;
+        METERING_SET_REFERENCE_NUMBER: string;
+        CONFIRMATION_REFERENCE_NUMBER: string;
+        NON_CYCLIC_TOLERANCE: string;
+        METER_PULSE_VALUE: string;
+        METER_MANUFACTURER_ORG_ID: string;
+        METER_LOCATION_DESCRIPTION: string;
+        METER_LOCATION_CODE: string;
+        METER_MODEL: string;
+        CORRECTOR_SERIAL_NUMBER: string;
+        METER_MECHANISM: string;
+        CORRECTED_READING_UNITS: string;
+    }
+}
+
+export namespace MetaV1 {
+    export const MetaV1Name = \\"metaV1.metaV1\\";
+    export interface MetaV1 {
+        eventId: string;
+        createdAt: number;
+        traceToken: string;
+        /**
+         * The url of the parsed Avro Data file from which the record was extracted.
+         */
+        sourcePath: string;
+        /**
+         * The md5Hash of the parsed Avro Data file from which the record was extracted.
+         */
+        md5Hash: string;
+        /**
+         * The url of the original raw flow file.
+         */
+        rawSourcePath: string;
+        /**
+         * The md5Hash of the original raw flow file.
+         */
+        rawSourceMd5Hash: string;
+    }
+}
+
+export namespace MbrSplitA00 {
+    export const ItemsName = \\"mbr.split.a00.Items\\";
+    export interface Items {
+        Organisation_ID: string;
+        flowName: string;
+        Creation_Date: string;
+        Creation_Time: string;
+        Generation_Number: string;
+    }
+}
+
+export namespace MbrSplit {
+    export const A00Name = \\"mbr.split.A00\\";
+    export interface A00 {
+        groupName: string;
+        items: MbrSplitA00.Items;
+    }
+    export const Z99Name = \\"mbr.split.Z99\\";
+    export interface Z99 {
+        groupName: string;
+        items: MbrSplitZ99.Items;
+    }
+}
+
+export namespace MbrSplitZ99 {
+    export const ItemsName = \\"mbr.split.z99.Items\\";
+    export interface Items {
+        Record_Count: string;
+    }
+}
+
+export namespace MbrSplitM03 {
+    export const M03Name = \\"mbr.split.m03.M03\\";
+    export interface M03 {
+        groupName: string;
+        items: MbrSplitM03M03.Items;
+        /**
+         * the Id of this record. Each record gets assigned a unique Id.
+         */
+        recordId: string;
+        metadata: MetaV1.MetaV1;
+        header: MbrSplit.A00;
+        footer: MbrSplit.Z99;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert M03.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 export type M03 = MbrSplitM03.M03;
@@ -1743,6 +2615,49 @@ export namespace ComAvroExample {
 "
 `;
 
+exports[`Avro ts test Should convert NestedRecordNamespace.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type NestRecordEvent = ComAvroExample.NestRecordEvent;
+
+export namespace ComAvroExample {
+    export const Level2RecordName = \\"com.avro.example.Level2Record\\";
+    export interface Level2Record {
+        id: string;
+    }
+    export const Level2SiblingName = \\"com.avro.example.Level2Sibling\\";
+    export interface Level2Sibling {
+        id: string;
+    }
+    export const Level1RecordName = \\"com.avro.example.Level1Record\\";
+    export interface Level1Record {
+        id: string;
+        child: {
+            \\"com.avro.example.Level2Record\\": ComAvroExample.Level2Record;
+            \\"com.avro.example.Level2Sibling\\"?: never;
+        } | {
+            \\"com.avro.example.Level2Record\\"?: never;
+            \\"com.avro.example.Level2Sibling\\": ComAvroExample.Level2Sibling;
+        };
+    }
+    export const Level1SiblingName = \\"com.avro.example.Level1Sibling\\";
+    export interface Level1Sibling {
+        id: string;
+    }
+    export const NestRecordEventName = \\"com.avro.example.NestRecordEvent\\";
+    export interface NestRecordEvent {
+        event: {
+            \\"com.avro.example.Level1Record\\": ComAvroExample.Level1Record;
+            \\"com.avro.example.Level1Sibling\\"?: never;
+        } | {
+            \\"com.avro.example.Level1Record\\"?: never;
+            \\"com.avro.example.Level1Sibling\\": ComAvroExample.Level1Sibling;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert NestedRecordNamespace.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -1787,6 +2702,45 @@ export namespace ComAvroExample {
 `;
 
 exports[`Avro ts test Should convert NestedWrappedType.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type Event = ComExampleAvro.Event;
+
+export namespace ComExampleAvro {
+    export const NestedFieldTypeName = \\"com.example.avro.NestedFieldType\\";
+    export interface NestedFieldType {
+        id: string;
+    }
+    export const FieldTypeAName = \\"com.example.avro.FieldTypeA\\";
+    export interface FieldTypeA {
+        id: string;
+        nested: ComExampleAvro.NestedFieldType;
+    }
+    export const FieldTypeBName = \\"com.example.avro.FieldTypeB\\";
+    export interface FieldTypeB {
+        id: string;
+    }
+    export const EventName = \\"com.example.avro.Event\\";
+    export interface Event {
+        field: {
+            \\"com.example.avro.FieldTypeA\\": ComExampleAvro.FieldTypeA;
+            \\"com.example.avro.FieldTypeB\\"?: never;
+            \\"com.example.avro.NestedFieldType\\"?: never;
+        } | {
+            \\"com.example.avro.FieldTypeA\\"?: never;
+            \\"com.example.avro.FieldTypeB\\": ComExampleAvro.FieldTypeB;
+            \\"com.example.avro.NestedFieldType\\"?: never;
+        } | {
+            \\"com.example.avro.FieldTypeA\\"?: never;
+            \\"com.example.avro.FieldTypeB\\"?: never;
+            \\"com.example.avro.NestedFieldType\\": ComExampleAvro.NestedFieldType;
+        };
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert NestedWrappedType.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 export type Event = ComExampleAvro.Event;
@@ -1910,6 +2864,52 @@ export namespace ComOvoenergyKafkaTestEvent {
 "
 `;
 
+exports[`Avro ts test Should convert NullableWrappedUnion.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type Test = ComOvoenergyKafkaTestEvent.Test;
+
+export namespace ComOvoenergyKafkaTestEvent {
+    export const AName = \\"com.ovoenergy.kafka.test.event.A\\";
+    export interface A {
+        foo: string;
+        bar: string;
+    }
+    export const BName = \\"com.ovoenergy.kafka.test.event.B\\";
+    export interface B {
+        /**
+         * Default: true
+         */
+        fuzz: boolean;
+    }
+    export const CName = \\"com.ovoenergy.kafka.test.event.C\\";
+    export interface C {
+        foo: string;
+        bar: string;
+    }
+    export const TestName = \\"com.ovoenergy.kafka.test.event.test\\";
+    export interface Test {
+        /**
+         * Default: \\"null\\"
+         */
+        event: null | {
+            \\"com.ovoenergy.kafka.test.event.A\\": ComOvoenergyKafkaTestEvent.A;
+            \\"com.ovoenergy.kafka.test.event.B\\"?: never;
+            \\"com.ovoenergy.kafka.test.event.C\\"?: never;
+        } | {
+            \\"com.ovoenergy.kafka.test.event.A\\"?: never;
+            \\"com.ovoenergy.kafka.test.event.B\\": ComOvoenergyKafkaTestEvent.B;
+            \\"com.ovoenergy.kafka.test.event.C\\"?: never;
+        } | {
+            \\"com.ovoenergy.kafka.test.event.A\\"?: never;
+            \\"com.ovoenergy.kafka.test.event.B\\"?: never;
+            \\"com.ovoenergy.kafka.test.event.C\\": ComOvoenergyKafkaTestEvent.C;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert NullableWrappedUnion.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -1980,6 +2980,30 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithDefault.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type RecordWithDefault = ComExampleAvro.RecordWithDefault;
+
+export namespace ComExampleAvro {
+    export const NoNeedForNamespaceName = \\"com.example.avro.NoNeedForNamespace\\";
+    export interface NoNeedForNamespace {
+        /**
+         * A fictitious id
+         */
+        id: string;
+    }
+    export const RecordWithDefaultName = \\"com.example.avro.RecordWithDefault\\";
+    export interface RecordWithDefault {
+        /**
+         * Default: null
+         */
+        pleaseNoNamespace: null | ComExampleAvro.NoNeedForNamespace;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithDefault.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2005,6 +3029,32 @@ export namespace ComExampleAvro {
 `;
 
 exports[`Avro ts test Should convert RecordWithDefaults.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type CreateUser = MyNamespaceMessages.CreateUser;
+
+export namespace MyNamespaceMessages {
+    export const CreateUserName = \\"my.namespace.messages.CreateUser\\";
+    export interface CreateUser {
+        userId: string;
+        /**
+         * Default: \\"John\\"
+         */
+        firstname: string | null;
+        /**
+         * Default: null
+         */
+        lastname: null | string;
+        /**
+         * Default: \\"john.doe@example.com\\"
+         */
+        email: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithDefaults.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 export type CreateUser = MyNamespaceMessages.CreateUser;
@@ -2103,6 +3153,56 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithEnum.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export namespace ComExampleAvro {
+    export const StatusName = \\"com.example.avro.status\\";
+    /**
+     * * \`PENDING\`: the user has started authorizing, but not yet finished
+     * * \`ACTIVE\`: the token should work
+     * * \`DENIED\`: the user declined the authorization
+     * * \`EXPIRED\`: the token used to work, but now it doesn't
+     * * \`REVOKED\`: the user has explicitly revoked the token
+     */
+    export enum Status {
+        ACTIVE = \\"ACTIVE\\",
+        INACTIVE = \\"INACTIVE\\"
+    }
+    export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        /**
+         * Indicator of whether this authorization is currently active, or has been revoked
+         */
+        status: ComExampleAvro.Status;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithEnum.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2151,6 +3251,64 @@ export namespace ComExampleAvro {
 `;
 
 exports[`Avro ts test Should convert RecordWithInterface.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export namespace ComExampleAvro {
+    export const EmailAddressName = \\"com.example.avro.EmailAddress\\";
+    /**
+     * Stores details about an email address that a user has associated with their account.
+     */
+    export interface EmailAddress {
+        /**
+         * The email address, e.g. \`foo@example.com\`
+         */
+        address: string;
+        /**
+         * true if the user has clicked the link in a confirmation email to this address.
+         *
+         * Default: false
+         */
+        verified: boolean;
+        /**
+         * Timestamp (milliseconds since epoch) when the email address was added to the account.
+         */
+        dateAdded: number;
+    }
+    export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        /**
+         * All email addresses on the user's account
+         */
+        emailAddresses: ComExampleAvro.EmailAddress[];
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithInterface.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 export type User = ComExampleAvro.User;
@@ -2294,6 +3452,34 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Moment } from \\"moment\\";
+
+export type Event = ComExampleAvro.Event;
+
+export namespace ComExampleAvro {
+    export const EventName = \\"com.example.avro.Event\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface Event {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * A timestamp for when the event was created (in epoch millis)
+         */
+        createdAt: Moment;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2323,6 +3509,38 @@ export namespace ComExampleAvro {
 `;
 
 exports[`Avro ts test Should convert RecordWithLogicalTypesImport.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Decimal } from \\"decimal.js\\";
+
+export type Event = ComExampleAvro.Event;
+
+export namespace ComExampleAvro {
+    export const EventName = \\"com.example.avro.Event\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface Event {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * A Decimal that we need a library for
+         */
+        decimalValue: Decimal;
+        /**
+         * Another decimal to make sure we don't add the import more than once
+         */
+        anotherDecimal: Decimal;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithLogicalTypesImport.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 import { Decimal } from \\"decimal.js\\";
@@ -2427,6 +3645,47 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithMap.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export namespace ComExampleAvro {
+    export const FooName = \\"com.example.avro.Foo\\";
+    export interface Foo {
+        label: string;
+    }
+    export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        mapField: {
+            [index: string]: ComExampleAvro.Foo;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithMap.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2482,6 +3741,20 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithNamedBooleanType.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type RecordWithNamedStringType = ComExampleAvro.RecordWithNamedStringType;
+
+export namespace ComExampleAvro {
+    export const RecordWithNamedStringTypeName = \\"com.example.avro.RecordWithNamedStringType\\";
+    export interface RecordWithNamedStringType {
+        pleaseNoNamespace: boolean;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithNamedBooleanType.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2510,6 +3783,20 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithNamedStringType.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type RecordWithNamedStringType = ComExampleAvro.RecordWithNamedStringType;
+
+export namespace ComExampleAvro {
+    export const RecordWithNamedStringTypeName = \\"com.example.avro.RecordWithNamedStringType\\";
+    export interface RecordWithNamedStringType {
+        pleaseNoNamespace: string;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithNamedStringType.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2525,6 +3812,44 @@ export namespace ComExampleAvro {
 `;
 
 exports[`Avro ts test Should convert RecordWithUnion.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export namespace ComExampleAvro {
+    export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        /**
+         * Default: null
+         */
+        unionType: null | string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithUnion.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 export type User = ComExampleAvro.User;
@@ -2634,6 +3959,40 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert SimpleRecord.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export namespace ComExampleAvro {
+    export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert SimpleRecord.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2669,6 +4028,39 @@ export namespace ComExampleAvro {
 `;
 
 exports[`Avro ts test Should convert TopLevelUnion.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type AvroType = {
+    \\"com.example.avro.Cancelled\\": ComExampleAvro.Cancelled;
+    \\"com.example.avro.Creation\\"?: never;
+} | {
+    \\"com.example.avro.Cancelled\\"?: never;
+    \\"com.example.avro.Creation\\": ComExampleAvro.Creation;
+};
+
+export namespace ComExampleAvroEvent {
+    export const EventMetadataName = \\"com.example.avro.event.EventMetadata\\";
+    export interface EventMetadata {
+        eventId: string;
+    }
+}
+
+export namespace ComExampleAvro {
+    export const CancelledName = \\"com.example.avro.Cancelled\\";
+    export interface Cancelled {
+        metadata: ComExampleAvroEvent.EventMetadata;
+        CancellationId: string;
+    }
+    export const CreationName = \\"com.example.avro.Creation\\";
+    export interface Creation {
+        metadata: ComExampleAvroEvent.EventMetadata;
+        creationId: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert TopLevelUnion.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 export type AvroType = {
@@ -2798,6 +4190,76 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert TradeCollection.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type TradeCollection = ComExampleAvro.TradeCollection;
+
+export namespace ComExampleAvro {
+    export const TradeTypeName = \\"com.example.avro.TradeType\\";
+    export enum TradeType {
+        Market = \\"Market\\",
+        Limit = \\"Limit\\"
+    }
+    export const TradeDirectionName = \\"com.example.avro.TradeDirection\\";
+    export enum TradeDirection {
+        Buy = \\"Buy\\",
+        Sell = \\"Sell\\"
+    }
+    export const TradeName = \\"com.example.avro.Trade\\";
+    export interface Trade {
+        /**
+         * Default: \\"\\"
+         */
+        id: string;
+        /**
+         * Default: 0
+         */
+        price: number;
+        /**
+         * Default: 0
+         */
+        amount: number;
+        /**
+         * Default: \\"\\"
+         */
+        datetime: string;
+        /**
+         * Default: 0
+         */
+        timestamp: number;
+        /**
+         * Default: null
+         */
+        type: null | ComExampleAvro.TradeType;
+        /**
+         * Default: null
+         */
+        side: null | ComExampleAvro.TradeDirection;
+    }
+    export const TradeCollectionName = \\"com.example.avro.TradeCollection\\";
+    export interface TradeCollection {
+        /**
+         * Default: \\"\\"
+         */
+        producerId: string;
+        /**
+         * Default: \\"\\"
+         */
+        exchange: string;
+        /**
+         * Default: \\"\\"
+         */
+        market: string;
+        /**
+         * Default: []
+         */
+        trades: ComExampleAvro.Trade[];
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert TradeCollection.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2863,6 +4325,66 @@ export namespace ComExampleAvro {
 `;
 
 exports[`Avro ts test Should convert TrfPreNexus.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type TrfPreNexus = ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.TrfPreNexus;
+
+export namespace ComExampleKafkaFlowsEventFlow {
+    export const DeletedName = \\"com.example.kafka.flows.event.flow.Deleted\\";
+    /**
+     * This type indicates that the data has been deleted according to the data retention policy.
+     */
+    export interface Deleted {
+        /**
+         * Additional information about reason behind the delete event
+         */
+        deleteReason: string;
+    }
+}
+
+export namespace ComExampleKafkaFlowsEventFlowSplitTrfPreNexus {
+    export const LapsedConfirmationDetsName = \\"com.example.kafka.flows.event.flow.split.trfPreNexus.LapsedConfirmationDets\\";
+    export interface LapsedConfirmationDets {
+        /**
+         * Default: \\"lapsedConfirmationDets\\"
+         */
+        groupName: string;
+    }
+    export const TransferOfOwnershipName = \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TransferOfOwnership\\";
+    export interface TransferOfOwnership {
+        /**
+         * Default: \\"transferOfOwnership\\"
+         */
+        groupName: string;
+    }
+    export const FlowContentsName = \\"com.example.kafka.flows.event.flow.split.trfPreNexus.FlowContents\\";
+    export interface FlowContents {
+        /**
+         * The split flow record.
+         */
+        record: {
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.LapsedConfirmationDets\\": ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.LapsedConfirmationDets;
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TransferOfOwnership\\"?: never;
+        } | {
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.LapsedConfirmationDets\\"?: never;
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TransferOfOwnership\\": ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.TransferOfOwnership;
+        };
+    }
+    export const TrfPreNexusName = \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TrfPreNexus\\";
+    export interface TrfPreNexus {
+        data: {
+            \\"com.example.kafka.flows.event.flow.Deleted\\": ComExampleKafkaFlowsEventFlow.Deleted;
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.FlowContents\\"?: never;
+        } | {
+            \\"com.example.kafka.flows.event.flow.Deleted\\"?: never;
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.FlowContents\\": ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.FlowContents;
+        };
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert TrfPreNexus.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 export type TrfPreNexus = ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.TrfPreNexus;
@@ -3126,6 +4648,162 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert User.avsc successfully using Typescript Enums 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export namespace ComExampleAvro {
+    export const EmailAddressName = \\"com.example.avro.EmailAddress\\";
+    /**
+     * Stores details about an email address that a user has associated with their account.
+     */
+    export interface EmailAddress {
+        /**
+         * The email address, e.g. \`foo@example.com\`
+         */
+        address: string;
+        /**
+         * true if the user has clicked the link in a confirmation email to this address.
+         *
+         * Default: false
+         */
+        verified: boolean;
+        /**
+         * Timestamp (milliseconds since epoch) when the email address was added to the account.
+         */
+        dateAdded: number;
+        /**
+         * Timestamp (milliseconds since epoch) when an email sent to this address last bounced. Reset to null when the address no longer bounces.
+         */
+        dateBounced: null | number;
+    }
+    export const OAuthStatusName = \\"com.example.avro.OAuthStatus\\";
+    /**
+     * * \`PENDING\`: the user has started authorizing, but not yet finished
+     * * \`ACTIVE\`: the token should work
+     * * \`DENIED\`: the user declined the authorization
+     * * \`EXPIRED\`: the token used to work, but now it doesn't
+     * * \`REVOKED\`: the user has explicitly revoked the token
+     */
+    export enum OAuthStatus {
+        PENDING = \\"PENDING\\",
+        ACTIVE = \\"ACTIVE\\",
+        DENIED = \\"DENIED\\",
+        EXPIRED = \\"EXPIRED\\",
+        REVOKED = \\"REVOKED\\"
+    }
+    export const TwitterAccountName = \\"com.example.avro.TwitterAccount\\";
+    /**
+     * Stores access credentials for one Twitter account, as granted to us by the user by OAuth.
+     */
+    export interface TwitterAccount {
+        /**
+         * Indicator of whether this authorization is currently active, or has been revoked
+         */
+        status: ComExampleAvro.OAuthStatus;
+        /**
+         * Twitter's numeric ID for this user
+         */
+        userId: number;
+        /**
+         * The twitter username for this account (can be changed by the user)
+         */
+        screenName: string;
+        /**
+         * The OAuth token for this Twitter account
+         */
+        oauthToken: string;
+        /**
+         * The OAuth secret, used for signing requests on behalf of this Twitter account. \`null\` whilst the OAuth flow is not yet complete.
+         */
+        oauthTokenSecret: null | string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user last authorized this Twitter account
+         */
+        dateAuthorized: number;
+    }
+    export const ToDoStatusName = \\"com.example.avro.ToDoStatus\\";
+    /**
+     * * \`HIDDEN\`: not currently visible, e.g. because it becomes actionable in future
+     * * \`ACTIONABLE\`: appears in the current to-do list
+     * * \`DONE\`: marked as done, but still appears in the list
+     * * \`ARCHIVED\`: marked as done and no longer visible
+     * * \`DELETED\`: not done and removed from list (preserved for undo purposes)
+     */
+    export enum ToDoStatus {
+        HIDDEN = \\"HIDDEN\\",
+        ACTIONABLE = \\"ACTIONABLE\\",
+        DONE = \\"DONE\\",
+        ARCHIVED = \\"ARCHIVED\\",
+        DELETED = \\"DELETED\\"
+    }
+    export const ToDoItemName = \\"com.example.avro.ToDoItem\\";
+    /**
+     * A record is one node in a To-Do item tree (every record can contain nested sub-records).
+     */
+    export interface ToDoItem {
+        /**
+         * User-selected state for this item (e.g. whether or not it is marked as done)
+         */
+        status: ComExampleAvro.ToDoStatus;
+        /**
+         * One-line summary of the item
+         */
+        title: string;
+        /**
+         * Detailed description (may contain HTML markup)
+         */
+        description: null | string;
+        /**
+         * Timestamp (milliseconds since epoch) at which the item should go from \`HIDDEN\` to \`ACTIONABLE\` status
+         */
+        snoozeDate: null | number;
+        /**
+         * List of children of this to-do tree node
+         */
+        subItems: ComExampleAvro.ToDoItem[];
+    }
+    export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        /**
+         * All email addresses on the user's account
+         */
+        emailAddresses: ComExampleAvro.EmailAddress[];
+        /**
+         * All Twitter accounts that the user has OAuthed
+         */
+        twitterAccounts: ComExampleAvro.TwitterAccount[];
+        /**
+         * The top-level items in the user's to-do list
+         */
+        toDoItems: ComExampleAvro.ToDoItem[];
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert User.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -3271,6 +4949,20 @@ export namespace ComExampleAvro {
 `;
 
 exports[`Avro ts test Should convert WeirdName.avsc successfully 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type RecordValue = ComAcmeMyapp.RecordValue;
+
+export namespace ComAcmeMyapp {
+    export const RecordValueName = \\"com.acme.myapp.record-value\\";
+    export interface RecordValue {
+        name: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert WeirdName.avsc successfully using Typescript Enums 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
 export type RecordValue = ComAcmeMyapp.RecordValue;

--- a/packages/avro-ts/test/avro/ComplexRecord.avsc
+++ b/packages/avro-ts/test/avro/ComplexRecord.avsc
@@ -71,11 +71,13 @@
     {
       "name": "status",
       "doc": "Indicator of whether this authorization is currently active, or has been revoked",
+      "default": "INACTIVE",
       "type": {
         "type": "enum",
         "name": "status",
         "doc": "* `PENDING`: the user has started authorizing, but not yet finished\n* `ACTIVE`: the token should work\n* `DENIED`: the user declined the authorization\n* `EXPIRED`: the token used to work, but now it doesn't\n* `REVOKED`: the user has explicitly revoked the token",
-        "symbols": ["ACTIVE", "INACTIVE"]
+        "symbols": ["ACTIVE", "INACTIVE"],
+        "default" : "ACTIVE"
       }
     }
   ]

--- a/packages/avro-ts/test/external-references.spec.ts
+++ b/packages/avro-ts/test/external-references.spec.ts
@@ -34,4 +34,25 @@ describe('Avro ts test', () => {
       expect(ts).toMatchSnapshot(file);
     }
   });
+
+  it('Should convert %s successfully using Typescript Enums', () => {
+    const external = avscFiles.reduce(
+      (acc, file) => ({
+        ...acc,
+        [`./${file}.external`]: toExternalContext(
+          JSON.parse(String(readFileSync(join(__dirname, 'external-references', file)))),
+        ),
+      }),
+      {},
+    );
+
+    for (const file of avscFiles) {
+      const ts = toTypeScript(
+        JSON.parse(String(readFileSync(join(__dirname, 'external-references', file)))),
+        { external, withTypescriptEnums: true },
+      );
+      writeFileSync(join(__dirname, '__generated__', file + '.external.ts'), ts);
+      expect(ts).toMatchSnapshot(file);
+    }
+  });
 });

--- a/packages/avro-ts/test/integration.spec.ts
+++ b/packages/avro-ts/test/integration.spec.ts
@@ -38,4 +38,18 @@ describe('Avro ts test', () => {
     writeFileSync(join(__dirname, '__generated__', file + '.ts'), ts);
     expect(ts).toMatchSnapshot();
   });
+
+  it.each(avscFiles)('Should convert %s successfully using Typescript Enums', (file) => {
+    const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
+    const ts = toTypeScript(avro, {
+      withTypescriptEnums: true,
+      logicalTypes: {
+        'timestamp-millis': { module: 'moment', named: 'Moment' },
+        date: 'string',
+        decimal: { module: 'decimal.js', named: 'Decimal' },
+      },
+    });
+    writeFileSync(join(__dirname, '__generated__', file + '.ts'), ts);
+    expect(ts).toMatchSnapshot();
+  });
 });

--- a/packages/avro-ts/test/integration.spec.ts
+++ b/packages/avro-ts/test/integration.spec.ts
@@ -25,20 +25,6 @@ describe('Avro ts test', () => {
     expect(ts).toMatchSnapshot();
   });
 
-  it.each(avscFiles)('Should convert %s successfully with default as optional', (file) => {
-    const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
-    const ts = toTypeScript(avro, {
-      logicalTypes: {
-        'timestamp-millis': { module: 'moment', named: 'Moment' },
-        date: 'string',
-        decimal: { module: 'decimal.js', named: 'Decimal' },
-      },
-      defaultsAsOptional: true,
-    });
-    writeFileSync(join(__dirname, '__generated__', file + '.ts'), ts);
-    expect(ts).toMatchSnapshot();
-  });
-
   it.each(avscFiles)('Should convert %s successfully using Typescript Enums', (file) => {
     const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
     const ts = toTypeScript(avro, {
@@ -48,6 +34,20 @@ describe('Avro ts test', () => {
         date: 'string',
         decimal: { module: 'decimal.js', named: 'Decimal' },
       },
+    });
+    writeFileSync(join(__dirname, '__generated__', file + '.ts'), ts);
+    expect(ts).toMatchSnapshot();
+  });
+
+  it.each(avscFiles)('Should convert %s successfully with default as optional', (file) => {
+    const avro: schema.RecordType = JSON.parse(String(readFileSync(join(__dirname, 'avro', file))));
+    const ts = toTypeScript(avro, {
+      logicalTypes: {
+        'timestamp-millis': { module: 'moment', named: 'Moment' },
+        date: 'string',
+        decimal: { module: 'decimal.js', named: 'Decimal' },
+      },
+      defaultsAsOptional: true,
     });
     writeFileSync(join(__dirname, '__generated__', file + '.ts'), ts);
     expect(ts).toMatchSnapshot();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,6 +2151,11 @@ avsc@^5.5.6:
   resolved "https://registry.yarnpkg.com/avsc/-/avsc-5.6.0.tgz#b05d308f719dc7c24a427a55dff4e1fb2fa41fca"
   integrity sha512-aZ/tCgSaXnIgYomdtSiYkJb5iStk9D0Qls/VXIGb+Z+seOQmgEA8YfzEPw9qgJYi3JyLVRwfta06ztVXtrhekA==
 
+avsc@^5.7.5:
+  version "5.7.5"
+  resolved "https://artifactory.nordstrom.com/artifactory/api/npm/npm/avsc/-/avsc-5.7.5.tgz#da1840506b3ff69e14b5f87ce511e9c384405166"
+  integrity sha512-vkyt1+sj6qaD9oMtqqLE2pZ2IcHI66kFx8lpnVuXp55SnNPjKghfOhVfZpaDwDPpY0oVWP3Qu1uHZWxF3E856A==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
This change is backwards compatible and won't break any existing clients. Adding an optional flag to enable Typescript enum conversion explained in https://github.com/ovotech/castle/issues/124. Once this is merged and published I can update `avro-ts-cli` to support this new flag as well. I am not sure if it's possible to bundle all changes into a single MR with lerna and inner dependencies.

Happy to address any feedback from maintainers.