### PR TITLE
handle naming collisions in named types

### DIFF
--- a/packages/avro-ts/test/enum-with-name.spec.ts
+++ b/packages/avro-ts/test/enum-with-name.spec.ts
@@ -1,0 +1,39 @@
+import { schema } from 'avsc';
+import { toTypeScript } from '../src';
+
+// For more info on why this text exists, see https://github.com/ovotech/castle/issues/126
+describe('enum with "Name" name in name', () => {
+  it('actually generates a union type when transforming an enum with "name" in the name', () => {
+    const schema = {
+      type: 'record',
+      name: 'Status',
+      namespace: 'com.example.avro',
+      fields: [
+        {
+          name: 'statusName',
+          type: {
+            type: 'enum',
+            name: 'StatusName',
+            symbols: ['ACTIVE', 'INACTIVE'],
+          },
+        },
+      ],
+    } as schema.RecordType;
+
+    const tsCode = toTypeScript(schema);
+
+    expect(tsCode).toEqual(`/* eslint-disable @typescript-eslint/no-namespace */
+
+export type Status = ComExampleAvro.Status;
+
+export namespace ComExampleAvro {
+    export const StatusNameName = "com.example.avro.StatusName";
+    export type StatusName = "ACTIVE" | "INACTIVE";
+    export const ComExampleAvroStatusName = "com.example.avro.Status";
+    export interface Status {
+        statusName: ComExampleAvro.StatusName;
+    }
+}
+`);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/ovotech/castle/issues/126

This PR addresses the issue detailed above by prepending the class-ified namespace to the "named" type whenever we detect that a naming collision is about to happen.