### PR TITLE
Make avro-mock-generator a peer dep

### DIFF
--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@ovotech/avro-kafkajs": "^0.7.1",
+    "@ovotech/avro-mock-generator": "^3.0.0",
     "@ovotech/castle": "^0.7.0",
     "@types/lodash.merge": "^4.6.6",
     "@typescript-eslint/eslint-plugin": "^4.15.1",

--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/blaise",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An API to generate mock payloads for @ovotech/castle using @ovotech/avro-mock-generator",
   "keywords": [
     "castle",

--- a/packages/blaise/package.json
+++ b/packages/blaise/package.json
@@ -9,7 +9,7 @@
     "mock",
     "kafka"
   ],
-  "author": "Nicolas Lagoutte <nicolas.lagoutte@ovoenergy.com>",
+  "author": "Nicolas Lagoutte <nicolas.lagoutte@kaluza.com>",
   "homepage": "https://github.com/ovotech/castle#readme",
   "license": "Apache-2.0",
   "main": "dist/index.js",
@@ -53,11 +53,11 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "@ovotech/avro-mock-generator": "^2.0.3",
     "lodash.merge": "^4.6.2",
     "ts-essentials": "^7.0.0"
   },
   "peerDependencies": {
+    "@ovotech/avro-mock-generator": "^2.0.3 || ^3.0.0",
     "@ovotech/castle": ">=0.3"
   }
 }


### PR DESCRIPTION
There's a major bump from avro-mock-generator, signatures are unchanged but a transitive dep (`uuid`) is dropping support for a bunch of platform and old node versions.

This made me choose to bundle it as a peer dependency from now on, so that blaise/castle users can choose to stick to the old version for now.

I've also fixed the author field