### PR TITLE
Publish avro-decimal to github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ commands:
     description: Set npm login
     steps:
       - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run: echo "//npm.pkg.github.com/:_authToken=${GITHUB_NPM_TOKEN}" >> ~/.npmrc
 
   yarn-save-cache:
     description: Save yarn packages cache
@@ -62,7 +63,7 @@ jobs:
       - npm-login
       - run: git config user.email "ovotech-ci@ovoenergy.com"
       - run: git config user.name "Ovotech CI"
-      - run: yarn lerna publish from-package --yes --no-verify-access
+      - run: yarn lerna publish from-package --yes
 
 workflows:
   version: 2

--- a/packages/avro-decimal/package.json
+++ b/packages/avro-decimal/package.json
@@ -36,5 +36,9 @@
   },
   "jest": {
     "preset": "../../jest.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
   }
 }


### PR DESCRIPTION
Unable to get lerna to publish to the default package registry (Stefan also had this issue, we're not sure why, seems to be credential related, but nothing we've tried works). So instead, publish it to our github package registry, and add a credential for the build to support that.