### PR TITLE
feat: type only namespaces

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "22"
+yarn = "1.22"

--- a/packages/avro-ts-cli/src/convert.ts
+++ b/packages/avro-ts-cli/src/convert.ts
@@ -15,6 +15,7 @@ interface Options {
   outputDir?: string;
   defaultsAsOptional?: boolean;
   withTypescriptEnums?: boolean;
+  experimentalTypeOnlyNamespaces?: boolean;
 }
 
 export const convert = (logger: { log: (msg: string) => void } = console): commander.Command =>
@@ -23,7 +24,14 @@ export const convert = (logger: { log: (msg: string) => void } = console): comma
     .arguments('[input...]')
     .option('-O, --output-dir <outputDir>', 'Directory to write typescript files to')
     .option('-e, --defaults-as-optional', 'Fields with defaults as optional')
-    .option('--with-typescript-enums', 'Flag to use Typescript Enums for Avro Enums instead of string union')
+    .option(
+      '--with-typescript-enums',
+      'Flag to use Typescript Enums for Avro Enums instead of string union',
+    )
+    .option(
+      '--experimental-type-only-namespaces',
+      'Emit type-only namespaces with runtime values in a sibling const object, compatible with TypeScript type stripping. Incompatible with --with-typescript-enums.',
+    )
     .option(
       '-l, --logical-type <logicalType>',
       'Logical type, example: date=string',
@@ -76,6 +84,7 @@ Example:
   avro-ts avro/*.avsc --output-dir other/dir
   avro-ts avro/*.avsc --defaults-as-optional
   avro-ts avro/*.avsc --with-typescript-enums
+  avro-ts avro/*.avsc --experimental-type-only-namespaces
   avro-ts avro/*.avsc --logical-type date=string --logical-type datetime=string
   avro-ts avro/*.avsc --logical-type-import decimal=Decimal:decimal.js
   avro-ts avro/*.avsc --logical-type-import-default decimal=Decimal:decimal.js
@@ -93,6 +102,7 @@ Example:
           outputDir,
           defaultsAsOptional,
           withTypescriptEnums,
+          experimentalTypeOnlyNamespaces,
         }: Options,
       ) => {
         if (files.length === 0) {
@@ -143,7 +153,13 @@ Example:
               {},
             );
 
-            const ts = toTypeScript(schema, { logicalTypes, external, defaultsAsOptional, withTypescriptEnums });
+            const ts = toTypeScript(schema, {
+              logicalTypes,
+              external,
+              defaultsAsOptional,
+              withTypescriptEnums,
+              experimentalTypeOnlyNamespaces,
+            });
             const outputFile = outputDir ? join(outputDir, `${basename(file)}.ts`) : `${file}.ts`;
             writeFileSync(outputFile, ts);
             const shortFile = file.replace(process.cwd(), '.');

--- a/packages/avro-ts/examples/temporal-logical-types.ts
+++ b/packages/avro-ts/examples/temporal-logical-types.ts
@@ -1,0 +1,39 @@
+import { toTypeScript } from '@ovotech/avro-ts';
+import { Schema } from 'avsc';
+
+const avro: Schema = {
+  type: 'record',
+  name: 'Event',
+  fields: [
+    { name: 'eventDate', type: { type: 'int', logicalType: 'date' } },
+    { name: 'startTimeMillis', type: { type: 'int', logicalType: 'time-millis' } },
+    { name: 'startTimeMicros', type: { type: 'long', logicalType: 'time-micros' } },
+    { name: 'createdAt', type: { type: 'long', logicalType: 'timestamp-millis' } },
+    { name: 'createdAtMicros', type: { type: 'long', logicalType: 'timestamp-micros' } },
+    { name: 'localCreatedAt', type: { type: 'long', logicalType: 'local-timestamp-millis' } },
+    { name: 'localCreatedAtMicros', type: { type: 'long', logicalType: 'local-timestamp-micros' } },
+    {
+      name: 'elapsed',
+      type: { type: 'fixed', name: 'Elapsed', size: 12, logicalType: 'duration' },
+    },
+  ],
+};
+
+// Temporal is a global as of Node 26+, so every avro date/time logical type can be mapped losslessly onto its
+// semantic Temporal counterpart
+const ts = toTypeScript(avro, {
+  logicalTypes: {
+    date: 'Temporal.PlainDate',
+    'time-millis': 'Temporal.PlainTime',
+    'time-micros': 'Temporal.PlainTime',
+    'timestamp-millis': 'Temporal.Instant',
+    'timestamp-micros': 'Temporal.Instant',
+    // local-timestamp-* does not encode timezone, but also should not be assumed to be UTC (therefore not Instant)
+    // PlainDateTime is probably the closest equivalent
+    'local-timestamp-millis': 'Temporal.PlainDateTime',
+    'local-timestamp-micros': 'Temporal.PlainDateTime',
+    duration: 'Temporal.Duration',
+  },
+});
+
+console.log(ts);

--- a/packages/avro-ts/package.json
+++ b/packages/avro-ts/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/ovotech/castle/tree/main/packages/avro-ts#readme",
   "scripts": {
     "test:js": "jest --runInBand",
-    "test:ts": "tsc test/integration.ts --strict --noEmit && ! tsc test/integration-should-fail.ts --strict --noEmit",
+    "test:ts": "tsc test/integration.ts --strict --noEmit && tsc test/integration-should-fail.ts --strict --noEmit",
     "test": "yarn test:js && yarn test:ts",
     "lint:prettier": "prettier --list-different {src,test}/**/*.ts",
     "lint:eslint": "eslint '{src,test}/**/*.ts'",

--- a/packages/avro-ts/src/convert.ts
+++ b/packages/avro-ts/src/convert.ts
@@ -11,7 +11,13 @@ import { isEnumType, convertEnumType } from './types/enum';
 import { isPrimitiveType, convertPrimitiveType } from './types/primitive';
 import { isFixedType, convertFixedType } from './types/fixed';
 import { withHeader, withImports } from '@ovotech/ts-compose/dist/document';
-import { fullName, firstUpperCase, nameParts, convertName } from './helpers';
+import {
+  fullName,
+  firstUpperCase,
+  nameParts,
+  convertName,
+  withSiblingObjects,
+} from './helpers';
 import * as ts from 'typescript';
 import { convertNamedType, isNamedType } from './types/named-type';
 
@@ -91,12 +97,22 @@ export const convertType: Convert = (context, type) => {
 };
 
 export const toTypeScript = (schema: Schema, initial: Context = {}): string => {
+  if (initial.experimentalTypeOnlyNamespaces && initial.withTypescriptEnums) {
+    throw new Error(
+      'experimentalTypeOnlyNamespaces cannot be combined with withTypescriptEnums: TypeScript enums cannot be stripped from type-only namespaces.',
+    );
+  }
+
   const contextWithRefs = collectRefs(schema, initial);
   const { context, type } = convertType(contextWithRefs, schema);
 
-  const contextWithHeader = context.namespaces
-    ? withHeader(context, '/* eslint-disable @typescript-eslint/no-namespace */')
+  const contextWithSiblings = context.experimentalTypeOnlyNamespaces
+    ? withSiblingObjects(context)
     : context;
+
+  const contextWithHeader = contextWithSiblings.namespaces
+    ? withHeader(contextWithSiblings, '/* eslint-disable @typescript-eslint/no-namespace */')
+    : contextWithSiblings;
 
   const name =
     ts.isTypeReferenceNode(type) && ts.isQualifiedName(type.typeName)

--- a/packages/avro-ts/src/helpers.ts
+++ b/packages/avro-ts/src/helpers.ts
@@ -24,40 +24,104 @@ export const nameParts = (fullName: string): [string] | [string, string] => {
     : [parts[0]];
 };
 
-export const namedType = (
+// A single const, like `UserName = "com.example.User"`.
+interface NamespaceConst {
+  name: string;
+  value: string;
+}
+
+// private symbol so that our internal accumlator it stays internal and doesn't pollute either public api
+// or ts-compose internals
+const siblingConsts = Symbol('siblingConsts');
+
+type Namespace = string;
+
+// The consts destined for each namespace's sibling object literal.
+type SiblingConsts = Record<Namespace, NamespaceConst[]>;
+
+type ContextWithSiblingConsts = Context & { [siblingConsts]?: SiblingConsts };
+
+// collect consts for a namespace's sibling object literal, returning a new context.
+const withSiblingConsts = (
+  context: ContextWithSiblingConsts,
+  namespaceName: Namespace,
+  consts: NamespaceConst[],
+): ContextWithSiblingConsts => {
+  const collected = context[siblingConsts] ?? {};
+  const existing = collected[namespaceName] ?? [];
+
+  return {
+    ...context,
+    [siblingConsts]: {
+      ...collected,
+      [namespaceName]: [...existing, ...consts],
+    },
+  };
+};
+
+// Declare consts inside the namespace.
+const withNamespaceConsts = (
+  context: Context,
+  namespaceName: Namespace,
+  consts: NamespaceConst[],
+): Context => {
+  let result = context;
+  for (const { name, value } of consts) {
+    result = withIdentifier(result, Node.Const({ name, isExport: true, value }), namespaceName);
+  }
+  return result;
+};
+
+// Emit each namespace's collected consts as a sibling `const <Namespace> = { ... }` object literal.
+export function withSiblingObjects(context: ContextWithSiblingConsts): Context {
+  let result: Context = context;
+
+  for (const [namespaceName, consts] of Object.entries(context[siblingConsts] ?? {})) {
+    const members: Record<string, string> = {};
+    for (const { name, value } of consts) {
+      members[name] = value;
+    }
+    result = withIdentifier(
+      result,
+      Node.Const({ name: namespaceName, isExport: true, multiline: true, value: members }),
+    );
+  }
+  return result;
+}
+
+export function namedType(
   type: ts.InterfaceDeclaration | ts.TypeAliasDeclaration | ts.EnumDeclaration,
   context: Context,
   schema: avroSchema.RecordType | avroSchema.EnumType,
   namespace?: string,
-): Document<ts.TypeNode, Context> => {
+): Document<ts.TypeNode, Context> {
   const name = convertName(firstUpperCase(schema.name));
   const namespaceName = namespace ? convertName(namespace) : undefined;
 
-  const fullName = namespaceName ? [namespaceName, name] : name;
+  // No namespace: the type is emitted at the top level, with no schema/name consts.
+  if (!namespace || !namespaceName) {
+    return document(withIdentifier(context, type), Type.Referance(name));
+  }
+
+  const reference = Type.Referance([namespaceName, name]);
   const fieldName = `${name}Name`;
   const schemaName = `${namespace}.${fieldName}`;
   const value = `${namespace}.${schema.name}`;
+  const schemaJson = JSON.stringify(schema);
 
-  const schemaValue = (name : string) => Node.Const({ name, isExport: true, value: JSON.stringify(schema) });
+  // On a name collision with an existing ref, prefix the const names with the namespace.
+  const prefix = context.refs && schemaName in context.refs ? namespaceName : '';
+  const schemaConstName = `${prefix}${name}Schema`;
+  const nameConstName = `${prefix}${fieldName}`;
 
-  const contextWithRef = namespace
-    ? /**
-       * If there is already a ref with the same name as our "named type", it means there is already
-       * a type with the same name and we're about to have a naming collision. To avoid this, we
-       * use the fully qualified name instead.
-       */
-      context.refs && schemaName in context.refs
-      ? withIdentifier(
-          withIdentifier(context, schemaValue(`${namespaceName}${name}Schema`), namespaceName),
-          Node.Const({ name: `${namespaceName}${fieldName}`, isExport: true, value }),
-          namespaceName,
-        )
-      : withIdentifier(
-          withIdentifier(context, schemaValue(`${name}Schema`), namespaceName),
-          Node.Const({ name: fieldName, isExport: true, value }),
-          namespaceName,
-        )
-    : context;
+  const consts: NamespaceConst[] = [
+    { name: schemaConstName, value: schemaJson },
+    { name: nameConstName, value },
+  ];
 
-  return document(withIdentifier(contextWithRef, type, namespaceName), Type.Referance(fullName));
-};
+  const contextWithConsts = context.experimentalTypeOnlyNamespaces
+    ? withSiblingConsts(context, namespaceName, consts)
+    : withNamespaceConsts(context, namespaceName, consts);
+
+  return document(withIdentifier(contextWithConsts, type, namespaceName), reference);
+}

--- a/packages/avro-ts/src/types.ts
+++ b/packages/avro-ts/src/types.ts
@@ -14,6 +14,11 @@ export interface Context extends DocumentContext {
   external?: { [file: string]: { [key: string]: Schema } };
   defaultsAsOptional?: boolean;
   withTypescriptEnums?: boolean;
+  /**
+   * Emit type-only namespaces, moving runtime consts into a sibling object literal so the output is
+   * compatible with TypeScript type stripping. Cannot be combined with `withTypescriptEnums`.
+   */
+  experimentalTypeOnlyNamespaces?: boolean;
 }
 
 export type Convert<TSchema = Schema, TType = ts.TypeNode> = (

--- a/packages/avro-ts/test/__snapshots__/external-references.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/external-references.spec.ts.snap
@@ -126,6 +126,141 @@ export namespace MyNamespaceMessages {
 "
 `;
 
+exports[`Avro ts test Should convert %s successfully using experimental type only namespaces: Address.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type Address = MyNamespaceData.Address;
+
+export const MyNamespaceData = {
+    AddressSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Address\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"my.namespace.data\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"street\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"zipcode\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"country\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    AddressName: \\"my.namespace.data.Address\\"
+};
+
+export namespace MyNamespaceData {
+    export interface Address {
+        street: string;
+        zipcode: string;
+        country: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using experimental type only namespaces: AvroJobStatus.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type AvroJobStatus = ComZenatonJobManagerData.AvroJobStatus;
+
+export const ComZenatonJobManagerData = {
+    AvroJobStatusSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AvroJobStatus\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.zenaton.jobManager.data\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"RUNNING_OK\\\\\\",\\\\\\"RUNNING_WARNING\\\\\\",\\\\\\"RUNNING_ERROR\\\\\\",\\\\\\"TERMINATED_COMPLETED\\\\\\",\\\\\\"TERMINATED_CANCELED\\\\\\"]}\\",
+    AvroJobStatusName: \\"com.zenaton.jobManager.data.AvroJobStatus\\"
+};
+
+export namespace ComZenatonJobManagerData {
+    export type AvroJobStatus = \\"RUNNING_OK\\" | \\"RUNNING_WARNING\\" | \\"RUNNING_ERROR\\" | \\"TERMINATED_COMPLETED\\" | \\"TERMINATED_CANCELED\\";
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using experimental type only namespaces: AvroJobStatusUpdated.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { ComZenatonJobManagerData as ComZenatonJobManagerDataAvroJobStatus } from \\"./AvroJobStatus.avsc.external\\";
+
+export type AvroJobStatusUpdated = ComZenatonJobManagerMessages.AvroJobStatusUpdated;
+
+export const ComZenatonJobManagerMessages = {
+    AvroJobStatusUpdatedSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AvroJobStatusUpdated\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.zenaton.jobManager.messages\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"jobId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"uuid\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"jobName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"oldStatus\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"com.zenaton.jobManager.data.AvroJobStatus\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"newStatus\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.zenaton.jobManager.data.AvroJobStatus\\\\\\"}]}\\",
+    AvroJobStatusUpdatedName: \\"com.zenaton.jobManager.messages.AvroJobStatusUpdated\\"
+};
+
+export namespace ComZenatonJobManagerMessages {
+    export interface AvroJobStatusUpdated {
+        jobId: string;
+        jobName: string;
+        oldStatus: null | ComZenatonJobManagerDataAvroJobStatus.AvroJobStatus;
+        newStatus: ComZenatonJobManagerDataAvroJobStatus.AvroJobStatus;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using experimental type only namespaces: CreateUser.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { MyNamespaceData as MyNamespaceDataAddress } from \\"./Address.avsc.external\\";
+
+export type CreateUser = MyNamespaceMessages.CreateUser;
+
+export const MyNamespaceMessages = {
+    CreateUserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"CreateUser\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"my.namespace.messages\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"uuid\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"type\\\\\\":\\\\\\"my.namespace.data.Address\\\\\\"}]}\\",
+    CreateUserName: \\"my.namespace.messages.CreateUser\\"
+};
+
+export namespace MyNamespaceMessages {
+    export interface CreateUser {
+        userId: string;
+        name: string;
+        address: MyNamespaceDataAddress.Address;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using experimental type only namespaces: Message.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { MyNamespaceMessages as MyNamespaceMessagesCreateUser } from \\"./CreateUser.avsc.external\\";
+
+import { MyNamespaceMessages as MyNamespaceMessagesUpdateAddress } from \\"./UpdateAddress.avsc.external\\";
+
+export type Message = MyNamespace.Message;
+
+export const MyNamespace = {
+    MessageTypeSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"MessageType\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"CreateUser\\\\\\",\\\\\\"UpdateAddress\\\\\\"]}\\",
+    MessageTypeName: \\"my.namespace.MessageType\\",
+    MessageSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Message\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"my.namespace\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"type\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"MessageType\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"CreateUser\\\\\\",\\\\\\"UpdateAddress\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"CreateUser\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"my.namespace.messages.CreateUser\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"UpdateAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"my.namespace.messages.UpdateAddress\\\\\\"],\\\\\\"default\\\\\\":null}]}\\",
+    MessageName: \\"my.namespace.Message\\"
+};
+
+export namespace MyNamespace {
+    export type MessageType = \\"CreateUser\\" | \\"UpdateAddress\\";
+    export interface Message {
+        type: MyNamespace.MessageType;
+        /**
+         * Default: null
+         */
+        CreateUser: null | MyNamespaceMessagesCreateUser.CreateUser;
+        /**
+         * Default: null
+         */
+        UpdateAddress: null | MyNamespaceMessagesUpdateAddress.UpdateAddress;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert %s successfully using experimental type only namespaces: UpdateAddress.avsc 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { MyNamespaceData as MyNamespaceDataAddress } from \\"./Address.avsc.external\\";
+
+export type UpdateAddress = MyNamespaceMessages.UpdateAddress;
+
+export const MyNamespaceMessages = {
+    UpdateAddressSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"UpdateAddress\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"my.namespace.messages\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"uuid\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"type\\\\\\":\\\\\\"my.namespace.data.Address\\\\\\"}]}\\",
+    UpdateAddressName: \\"my.namespace.messages.UpdateAddress\\"
+};
+
+export namespace MyNamespaceMessages {
+    export interface UpdateAddress {
+        userId: string;
+        address: MyNamespaceDataAddress.Address;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert %s successfully: Address.avsc 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 

--- a/packages/avro-ts/test/__snapshots__/integration.spec.ts.snap
+++ b/packages/avro-ts/test/__snapshots__/integration.spec.ts.snap
@@ -252,6 +252,135 @@ export namespace UkCoBoostpowerSupportKafkaMessages {
 "
 `;
 
+exports[`Avro ts test Should convert BalanceAdjustment.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Moment } from \\"moment\\";
+
+export type BalanceAdjustment = UkCoBoostpowerSupportKafkaMessages.BalanceAdjustment;
+
+export const ComOvoenergyKafkaCommonEvent = {
+    ConfigSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Config\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"tokenId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    ConfigName: \\"com.ovoenergy.kafka.common.event.Config\\",
+    ConfigExtendedSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ConfigExtended\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"tokenId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"extensionId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    ConfigExtendedName: \\"com.ovoenergy.kafka.common.event.ConfigExtended\\",
+    EventMetadataSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Metadata, to be used in each event class\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A globally unique ID for this Kafka message\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"A timestamp for when the event was created (in epoch millis)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"config\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Config\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"tokenId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ConfigExtended\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"tokenId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"extensionId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}]}]}\\",
+    EventMetadataName: \\"com.ovoenergy.kafka.common.event.EventMetadata\\"
+};
+
+export const UkCoBoostpowerSupportKafkaMessages = {
+    FuelSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Fuel\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Gas\\\\\\",\\\\\\"Electricity\\\\\\"]}\\",
+    FuelName: \\"uk.co.boostpower.support.kafka.messages.Fuel\\",
+    BalanceAdjustmentRequestSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"BalanceAdjustmentRequest\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Balance Adjustment request has been sent\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"jobId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A unique balance adjustment job id. Will correspond with the jobId of BalanceAdjustmentResponse\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. Gentrack Account ID. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"msn\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Meter Serial Number of the meter having its balance adjusted\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mpxn\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A Meter Point Administration Number (Electricity) or Meter Point Reference Number (Gas). It is expected that the specified meter supplies this Supply Point.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"fuel\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Fuel\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Gas\\\\\\",\\\\\\"Electricity\\\\\\"]},\\\\\\"doc\\\\\\":\\\\\\"Type of fuel of the meter\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"amount\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"thousands-of-a-penny\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The amount the balance was adjusted with, in thousands of a penny\\\\\\"}]}\\",
+    BalanceAdjustmentRequestName: \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\",
+    StatusSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Status\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Error\\\\\\",\\\\\\"Success\\\\\\"]}\\",
+    StatusName: \\"uk.co.boostpower.support.kafka.messages.Status\\",
+    BalanceAdjustmentResponseSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"BalanceAdjustmentResponse\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Balance Adjustment Completion\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"jobId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A unique adjustment job id. Will correspond with the jobId S2BalanceAdjustmentRequest\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Status\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Error\\\\\\",\\\\\\"Success\\\\\\"]},\\\\\\"doc\\\\\\":\\\\\\"The status of the balance adjustment when its completed\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"balance\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"thousands-of-a-penny\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The resulting the balance after the adjustemt, in thousands of a penny\\\\\\"}]}\\",
+    BalanceAdjustmentResponseName: \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\",
+    BalanceAdjustmentSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"BalanceAdjustment\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"uk.co.boostpower.support.kafka.messages\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A balance adjustment request and response events\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Metadata, to be used in each event class\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A globally unique ID for this Kafka message\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"A timestamp for when the event was created (in epoch millis)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"config\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Config\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"tokenId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ConfigExtended\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"tokenId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"extensionId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}]}]}},{\\\\\\"name\\\\\\":\\\\\\"event\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"BalanceAdjustmentRequest\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Balance Adjustment request has been sent\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"jobId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A unique balance adjustment job id. Will correspond with the jobId of BalanceAdjustmentResponse\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. Gentrack Account ID. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"msn\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Meter Serial Number of the meter having its balance adjusted\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mpxn\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A Meter Point Administration Number (Electricity) or Meter Point Reference Number (Gas). It is expected that the specified meter supplies this Supply Point.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"fuel\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Fuel\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Gas\\\\\\",\\\\\\"Electricity\\\\\\"]},\\\\\\"doc\\\\\\":\\\\\\"Type of fuel of the meter\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"amount\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"thousands-of-a-penny\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The amount the balance was adjusted with, in thousands of a penny\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"BalanceAdjustmentResponse\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Balance Adjustment Completion\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"jobId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A unique adjustment job id. Will correspond with the jobId S2BalanceAdjustmentRequest\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Status\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Error\\\\\\",\\\\\\"Success\\\\\\"]},\\\\\\"doc\\\\\\":\\\\\\"The status of the balance adjustment when its completed\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"balance\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"thousands-of-a-penny\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The resulting the balance after the adjustemt, in thousands of a penny\\\\\\"}]}]}]}\\",
+    BalanceAdjustmentName: \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustment\\"
+};
+
+export namespace ComOvoenergyKafkaCommonEvent {
+    export interface Config {
+        tokenId: string;
+    }
+    export interface ConfigExtended {
+        tokenId: string;
+        extensionId: string;
+    }
+    /**
+     * Metadata, to be used in each event class
+     */
+    export interface EventMetadata {
+        /**
+         * A globally unique ID for this Kafka message
+         */
+        eventId: string;
+        /**
+         * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+         */
+        traceToken: string;
+        /**
+         * A timestamp for when the event was created (in epoch millis)
+         */
+        createdAt: Moment;
+        config: {
+            \\"com.ovoenergy.kafka.common.event.Config\\": ComOvoenergyKafkaCommonEvent.Config;
+            \\"com.ovoenergy.kafka.common.event.ConfigExtended\\"?: never;
+        } | {
+            \\"com.ovoenergy.kafka.common.event.Config\\"?: never;
+            \\"com.ovoenergy.kafka.common.event.ConfigExtended\\": ComOvoenergyKafkaCommonEvent.ConfigExtended;
+        };
+    }
+}
+
+export namespace UkCoBoostpowerSupportKafkaMessages {
+    export type Fuel = \\"Gas\\" | \\"Electricity\\";
+    /**
+     * Balance Adjustment request has been sent
+     */
+    export interface BalanceAdjustmentRequest {
+        /**
+         * A unique balance adjustment job id. Will correspond with the jobId of BalanceAdjustmentResponse
+         */
+        jobId: string;
+        /**
+         * Unique identifier for the customer. Gentrack Account ID. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * Meter Serial Number of the meter having its balance adjusted
+         */
+        msn: string;
+        /**
+         * A Meter Point Administration Number (Electricity) or Meter Point Reference Number (Gas). It is expected that the specified meter supplies this Supply Point.
+         */
+        mpxn: string;
+        /**
+         * Type of fuel of the meter
+         */
+        fuel: UkCoBoostpowerSupportKafkaMessages.Fuel;
+        /**
+         * The amount the balance was adjusted with, in thousands of a penny
+         */
+        amount: number;
+    }
+    export type Status = \\"Error\\" | \\"Success\\";
+    /**
+     * Balance Adjustment Completion
+     */
+    export interface BalanceAdjustmentResponse {
+        /**
+         * A unique adjustment job id. Will correspond with the jobId S2BalanceAdjustmentRequest
+         */
+        jobId: string;
+        /**
+         * The status of the balance adjustment when its completed
+         */
+        status: UkCoBoostpowerSupportKafkaMessages.Status;
+        /**
+         * The resulting the balance after the adjustemt, in thousands of a penny
+         */
+        balance: number;
+    }
+    /**
+     * A balance adjustment request and response events
+     */
+    export interface BalanceAdjustment {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        event: {
+            \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\": UkCoBoostpowerSupportKafkaMessages.BalanceAdjustmentRequest;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentRequest\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceAdjustmentResponse\\": UkCoBoostpowerSupportKafkaMessages.BalanceAdjustmentResponse;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert BalanceAdjustment.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -871,6 +1000,269 @@ export namespace ComExampleKafkaCommsContent {
 "
 `;
 
+exports[`Avro ts test Should convert CommUpdateType.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Moment } from \\"moment\\";
+
+export type CommunicationUpdate = ComExampleKafkaComms.CommunicationUpdate;
+
+export const ComExampleKafkaCommonEvent = {
+    EventMetadataSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.common.event\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}}]}\\",
+    EventMetadataName: \\"com.example.kafka.common.event.EventMetadata\\"
+};
+
+export const ComExampleKafkaComms = {
+    TemplateManifestSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TemplateManifest\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"version\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.TemplateManifest\\\\\\",\\\\\\"com.example.comms.model.TemplateManifest\\\\\\"]}\\",
+    TemplateManifestName: \\"com.example.kafka.comms.TemplateManifest\\",
+    TemplateSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Template\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"manifest\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TemplateManifest\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"version\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.TemplateManifest\\\\\\",\\\\\\"com.example.comms.model.TemplateManifest\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"commType\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Template\\\\\\"]}\\",
+    TemplateName: \\"com.example.kafka.comms.Template\\",
+    PostalAddressSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"PostalAddress\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"contactName\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"company\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"line1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"line2\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"town\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"county\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postcode\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"country\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.PostalAddress\\\\\\"]}\\",
+    PostalAddressName: \\"com.example.kafka.comms.PostalAddress\\",
+    FailureSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Failure\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"at\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"code\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"reason\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Failure\\\\\\"]}\\",
+    FailureName: \\"com.example.kafka.comms.Failure\\",
+    AttachmentSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Attachment\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"uri\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"fileName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Attachment\\\\\\"]}\\",
+    AttachmentName: \\"com.example.kafka.comms.Attachment\\",
+    SpecialRequirementsSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"SpecialRequirements\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"preferences\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":\\\\\\"string\\\\\\"}}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.SpecialRequirements\\\\\\"]}\\",
+    SpecialRequirementsName: \\"com.example.kafka.comms.SpecialRequirements\\",
+    CommunicationSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Communication\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"brand\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"template\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Template\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"manifest\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TemplateManifest\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"version\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.TemplateManifest\\\\\\",\\\\\\"com.example.comms.model.TemplateManifest\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"commType\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Template\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"description\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"source\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"isCanary\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"triggeredAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"scheduledAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"orchestratedAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"composedAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"issuedForDeliveryAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"deliveredAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"expireAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"deliverTo\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Customer\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"DeliverTo\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"profileId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"aliases\\\\\\":[\\\\\\"customerId\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"contactDetails\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ContactDetails\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"emailAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"phoneNumber\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postalAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"PostalAddress\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"contactName\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"company\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"line1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"line2\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"town\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"county\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postcode\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"country\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.PostalAddress\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.DeliverTo.ContactDetails\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.DeliverTo.Customer\\\\\\"]},\\\\\\"DeliverTo.ContactDetails\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"recipient\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Email\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"emailAddress\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Email\\\\\\"]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Phone\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"phoneNumber\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Phone\\\\\\"]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Postal\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"postalAddress\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.example.kafka.comms.PostalAddress\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Postal\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"channel\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"failure\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Failure\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"at\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"code\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"reason\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Failure\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"content\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Email\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"sender\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"subject\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"textBody\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Email\\\\\\"]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Sms\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Sms\\\\\\"]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Print\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Print\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"attachments\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Attachment\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"uri\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"fileName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Attachment\\\\\\"]}},\\\\\\"default\\\\\\":[]},{\\\\\\"name\\\\\\":\\\\\\"specialRequirements\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"SpecialRequirements\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"preferences\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":\\\\\\"string\\\\\\"}}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.SpecialRequirements\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Communication\\\\\\"]}\\",
+    CommunicationName: \\"com.example.kafka.comms.Communication\\",
+    CommunicationUpdateSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"CommunicationUpdate\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.common.event\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}}]}},{\\\\\\"name\\\\\\":\\\\\\"communication\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Communication\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"brand\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"template\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Template\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"manifest\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TemplateManifest\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"version\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.TemplateManifest\\\\\\",\\\\\\"com.example.comms.model.TemplateManifest\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"commType\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Template\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"description\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"source\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"isCanary\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"triggeredAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"scheduledAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"orchestratedAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"composedAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"issuedForDeliveryAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"deliveredAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"expireAt\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"deliverTo\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Customer\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"DeliverTo\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"profileId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"aliases\\\\\\":[\\\\\\"customerId\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"contactDetails\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ContactDetails\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"emailAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"phoneNumber\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postalAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"PostalAddress\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"contactName\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"company\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"line1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"line2\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"town\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"county\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postcode\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"country\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.PostalAddress\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.DeliverTo.ContactDetails\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.DeliverTo.Customer\\\\\\"]},\\\\\\"DeliverTo.ContactDetails\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"recipient\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Email\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"emailAddress\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Email\\\\\\"]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Phone\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"phoneNumber\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Phone\\\\\\"]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Postal\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"postalAddress\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.example.kafka.comms.PostalAddress\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Postal\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"channel\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"failure\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Failure\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"at\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"code\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"reason\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Failure\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"content\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Email\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"sender\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"subject\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"textBody\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Email\\\\\\"]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Sms\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Sms\\\\\\"]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Print\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Print\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"attachments\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Attachment\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"uri\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"fileName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Attachment\\\\\\"]}},\\\\\\"default\\\\\\":[]},{\\\\\\"name\\\\\\":\\\\\\"specialRequirements\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"SpecialRequirements\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"preferences\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":\\\\\\"string\\\\\\"}}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.SpecialRequirements\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Communication\\\\\\"]}}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.snapshot.CommunicationUpdate\\\\\\"]}\\",
+    CommunicationUpdateName: \\"com.example.kafka.comms.CommunicationUpdate\\"
+};
+
+export const DeliverTo = {
+    ContactDetailsSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ContactDetails\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"emailAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"phoneNumber\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postalAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"PostalAddress\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"contactName\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"company\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"line1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"line2\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"town\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"county\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postcode\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"country\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.PostalAddress\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.DeliverTo.ContactDetails\\\\\\"],\\\\\\"namespace\\\\\\":\\\\\\"DeliverTo\\\\\\"}\\",
+    ContactDetailsName: \\"DeliverTo.ContactDetails\\",
+    CustomerSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Customer\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"DeliverTo\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"profileId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"aliases\\\\\\":[\\\\\\"customerId\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"contactDetails\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ContactDetails\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"emailAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"phoneNumber\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postalAddress\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"PostalAddress\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"contactName\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"company\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"line1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"line2\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"town\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"county\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"postcode\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"country\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.PostalAddress\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.DeliverTo.ContactDetails\\\\\\"]}],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.DeliverTo.Customer\\\\\\"]}\\",
+    CustomerName: \\"DeliverTo.Customer\\"
+};
+
+export const ComExampleKafkaCommsRecipient = {
+    EmailSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Email\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"emailAddress\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Email\\\\\\"]}\\",
+    EmailName: \\"com.example.kafka.comms.Recipient.Email\\",
+    PhoneSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Phone\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"phoneNumber\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Phone\\\\\\"]}\\",
+    PhoneName: \\"com.example.kafka.comms.Recipient.Phone\\",
+    PostalSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Postal\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Recipient\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"postalAddress\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.example.kafka.comms.PostalAddress\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Recipient.Postal\\\\\\"]}\\",
+    PostalName: \\"com.example.kafka.comms.Recipient.Postal\\"
+};
+
+export const ComExampleKafkaCommsContent = {
+    EmailSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Email\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"sender\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"subject\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"textBody\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Email\\\\\\"]}\\",
+    EmailName: \\"com.example.kafka.comms.Content.Email\\",
+    SmsSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Sms\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Sms\\\\\\"]}\\",
+    SmsName: \\"com.example.kafka.comms.Content.Sms\\",
+    PrintSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Print\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.comms.Content\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"body\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"aliases\\\\\\":[\\\\\\"com.example.kafka.comms.event.Content.Print\\\\\\"]}\\",
+    PrintName: \\"com.example.kafka.comms.Content.Print\\"
+};
+
+export namespace ComExampleKafkaCommonEvent {
+    export interface EventMetadata {
+        eventId: string;
+        traceToken: string;
+        createdAt: Moment;
+    }
+}
+
+export namespace ComExampleKafkaComms {
+    export interface TemplateManifest {
+        id: string;
+        version: string;
+    }
+    export interface Template {
+        manifest: ComExampleKafkaComms.TemplateManifest;
+        name: string;
+        commType: string;
+    }
+    export interface PostalAddress {
+        /**
+         * Default: null
+         */
+        contactName: null | string;
+        /**
+         * Default: null
+         */
+        company: null | string;
+        line1: string;
+        /**
+         * Default: null
+         */
+        line2: null | string;
+        town: string;
+        /**
+         * Default: null
+         */
+        county: null | string;
+        postcode: string;
+        /**
+         * Default: null
+         */
+        country: null | string;
+    }
+    export interface Failure {
+        at: Moment;
+        code: string;
+        reason: string;
+    }
+    export interface Attachment {
+        uri: string;
+        fileName: string;
+    }
+    export interface SpecialRequirements {
+        preferences: string[];
+    }
+    export interface Communication {
+        id: string;
+        traceToken: string;
+        brand: string;
+        template: ComExampleKafkaComms.Template;
+        status: string;
+        description: string;
+        source: string;
+        isCanary: boolean;
+        triggeredAt: Moment;
+        /**
+         * Default: null
+         */
+        scheduledAt: null | Moment;
+        /**
+         * Default: null
+         */
+        orchestratedAt: null | Moment;
+        /**
+         * Default: null
+         */
+        composedAt: null | Moment;
+        /**
+         * Default: null
+         */
+        issuedForDeliveryAt: null | Moment;
+        /**
+         * Default: null
+         */
+        deliveredAt: null | Moment;
+        /**
+         * Default: null
+         */
+        expireAt: null | Moment;
+        deliverTo: {
+            \\"DeliverTo.Customer\\": DeliverTo.Customer;
+            \\"DeliverTo.ContactDetails\\"?: never;
+        } | {
+            \\"DeliverTo.Customer\\"?: never;
+            \\"DeliverTo.ContactDetails\\": DeliverTo.ContactDetails;
+        };
+        /**
+         * Default: null
+         */
+        recipient: null | {
+            \\"com.example.kafka.comms.Recipient.Email\\": ComExampleKafkaCommsRecipient.Email;
+            \\"com.example.kafka.comms.Recipient.Phone\\"?: never;
+            \\"com.example.kafka.comms.Recipient.Postal\\"?: never;
+        } | {
+            \\"com.example.kafka.comms.Recipient.Email\\"?: never;
+            \\"com.example.kafka.comms.Recipient.Phone\\": ComExampleKafkaCommsRecipient.Phone;
+            \\"com.example.kafka.comms.Recipient.Postal\\"?: never;
+        } | {
+            \\"com.example.kafka.comms.Recipient.Email\\"?: never;
+            \\"com.example.kafka.comms.Recipient.Phone\\"?: never;
+            \\"com.example.kafka.comms.Recipient.Postal\\": ComExampleKafkaCommsRecipient.Postal;
+        };
+        /**
+         * Default: null
+         */
+        channel: null | string;
+        /**
+         * Default: null
+         */
+        failure: null | ComExampleKafkaComms.Failure;
+        /**
+         * Default: null
+         */
+        content: null | {
+            \\"com.example.kafka.comms.Content.Email\\": ComExampleKafkaCommsContent.Email;
+            \\"com.example.kafka.comms.Content.Sms\\"?: never;
+            \\"com.example.kafka.comms.Content.Print\\"?: never;
+        } | {
+            \\"com.example.kafka.comms.Content.Email\\"?: never;
+            \\"com.example.kafka.comms.Content.Sms\\": ComExampleKafkaCommsContent.Sms;
+            \\"com.example.kafka.comms.Content.Print\\"?: never;
+        } | {
+            \\"com.example.kafka.comms.Content.Email\\"?: never;
+            \\"com.example.kafka.comms.Content.Sms\\"?: never;
+            \\"com.example.kafka.comms.Content.Print\\": ComExampleKafkaCommsContent.Print;
+        };
+        /**
+         * Default: []
+         */
+        attachments: ComExampleKafkaComms.Attachment[];
+        /**
+         * Default: null
+         */
+        specialRequirements: null | ComExampleKafkaComms.SpecialRequirements;
+    }
+    export interface CommunicationUpdate {
+        metadata: ComExampleKafkaCommonEvent.EventMetadata;
+        communication: ComExampleKafkaComms.Communication;
+    }
+}
+
+export namespace DeliverTo {
+    export interface ContactDetails {
+        /**
+         * Default: null
+         */
+        emailAddress: null | string;
+        /**
+         * Default: null
+         */
+        phoneNumber: null | string;
+        /**
+         * Default: null
+         */
+        postalAddress: null | ComExampleKafkaComms.PostalAddress;
+    }
+    export interface Customer {
+        profileId: string;
+        /**
+         * Default: null
+         */
+        contactDetails: null | DeliverTo.ContactDetails;
+    }
+}
+
+export namespace ComExampleKafkaCommsRecipient {
+    export interface Email {
+        emailAddress: string;
+    }
+    export interface Phone {
+        phoneNumber: string;
+    }
+    export interface Postal {
+        postalAddress: ComExampleKafkaComms.PostalAddress;
+    }
+}
+
+export namespace ComExampleKafkaCommsContent {
+    export interface Email {
+        sender: string;
+        subject: string;
+        body: string;
+        /**
+         * Default: null
+         */
+        textBody: null | string;
+    }
+    export interface Sms {
+        body: string;
+    }
+    export interface Print {
+        body: string;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert CommUpdateType.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -1252,6 +1644,93 @@ export namespace ComExampleAvro {
     }
     export const UserSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mapField\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"map\\\\\\",\\\\\\"values\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Foo\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"label\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}}},{\\\\\\"name\\\\\\":\\\\\\"emailAddresses\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"All email addresses on the user's account\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EmailAddress\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores details about an email address that a user has associated with their account.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The email address, e.g. \`foo@example.com\`\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"verified\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"true if the user has clicked the link in a confirmation email to this address.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":false},{\\\\\\"name\\\\\\":\\\\\\"dateAdded\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the email address was added to the account.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"}]}}},{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Indicator of whether this authorization is currently active, or has been revoked\\\\\\",\\\\\\"default\\\\\\":\\\\\\"INACTIVE\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ACTIVE\\\\\\",\\\\\\"INACTIVE\\\\\\"],\\\\\\"default\\\\\\":\\\\\\"ACTIVE\\\\\\"}}]}\\";
     export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        mapField: {
+            [index: string]: ComExampleAvro.Foo;
+        };
+        /**
+         * All email addresses on the user's account
+         */
+        emailAddresses: ComExampleAvro.EmailAddress[];
+        /**
+         * Indicator of whether this authorization is currently active, or has been revoked
+         *
+         * Default: \\"INACTIVE\\"
+         */
+        status: ComExampleAvro.Status;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert ComplexRecord.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export const ComExampleAvro = {
+    FooSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Foo\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"label\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    FooName: \\"com.example.avro.Foo\\",
+    EmailAddressSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EmailAddress\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores details about an email address that a user has associated with their account.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The email address, e.g. \`foo@example.com\`\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"verified\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"true if the user has clicked the link in a confirmation email to this address.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":false},{\\\\\\"name\\\\\\":\\\\\\"dateAdded\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the email address was added to the account.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"}]}\\",
+    EmailAddressName: \\"com.example.avro.EmailAddress\\",
+    StatusSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ACTIVE\\\\\\",\\\\\\"INACTIVE\\\\\\"],\\\\\\"default\\\\\\":\\\\\\"ACTIVE\\\\\\"}\\",
+    StatusName: \\"com.example.avro.status\\",
+    UserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mapField\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"map\\\\\\",\\\\\\"values\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Foo\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"label\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}}},{\\\\\\"name\\\\\\":\\\\\\"emailAddresses\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"All email addresses on the user's account\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EmailAddress\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores details about an email address that a user has associated with their account.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The email address, e.g. \`foo@example.com\`\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"verified\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"true if the user has clicked the link in a confirmation email to this address.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":false},{\\\\\\"name\\\\\\":\\\\\\"dateAdded\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the email address was added to the account.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"}]}}},{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Indicator of whether this authorization is currently active, or has been revoked\\\\\\",\\\\\\"default\\\\\\":\\\\\\"INACTIVE\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ACTIVE\\\\\\",\\\\\\"INACTIVE\\\\\\"],\\\\\\"default\\\\\\":\\\\\\"ACTIVE\\\\\\"}}]}\\",
+    UserName: \\"com.example.avro.User\\"
+};
+
+export namespace ComExampleAvro {
+    export interface Foo {
+        label: string;
+    }
+    /**
+     * Stores details about an email address that a user has associated with their account.
+     */
+    export interface EmailAddress {
+        /**
+         * The email address, e.g. \`foo@example.com\`
+         */
+        address: string;
+        /**
+         * true if the user has clicked the link in a confirmation email to this address.
+         *
+         * Default: false
+         */
+        verified: boolean;
+        /**
+         * Timestamp (milliseconds since epoch) when the email address was added to the account.
+         */
+        dateAdded: number;
+    }
+    /**
+     * * \`PENDING\`: the user has started authorizing, but not yet finished
+     * * \`ACTIVE\`: the token should work
+     * * \`DENIED\`: the user declined the authorization
+     * * \`EXPIRED\`: the token used to work, but now it doesn't
+     * * \`REVOKED\`: the user has explicitly revoked the token
+     */
+    export type Status = \\"ACTIVE\\" | \\"INACTIVE\\";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
      *
@@ -1940,6 +2419,294 @@ export namespace UkCoBoostpowerSupportKafkaMessages {
 "
 `;
 
+exports[`Avro ts test Should convert ComplexUnionLogicalTypes.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Moment } from \\"moment\\";
+
+export type AccountMigrationEvent = UkCoBoostpowerSupportKafkaMessages.AccountMigrationEvent;
+
+export const ComOvoenergyKafkaCommonEvent = {
+    EventMetadataSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Metadata, to be used in each event class\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A globally unique ID for this Kafka message\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"A timestamp for when the event was created (in epoch millis)\\\\\\"}]}\\",
+    EventMetadataName: \\"com.ovoenergy.kafka.common.event.EventMetadata\\"
+};
+
+export const UkCoBoostpowerSupportKafkaMessages = {
+    AccountMigrationCancelledEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationCancelledEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Migration Service. Before T2 signals that a siemens account migration has been cancelled. Migration is about to be restarted for the same account that means a new AccountMigrationScheduledEvent with a new flow id will be sent.Consumers should not react on this in normal case.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Metadata, to be used in each event class\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A globally unique ID for this Kafka message\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"A timestamp for when the event was created (in epoch millis)\\\\\\"}]}},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mpan\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The unique national reference for Meter Point Administration Number\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"cancelledAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration was cancelled (in epoch millis)\\\\\\"}]}\\",
+    AccountMigrationCancelledEventName: \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\",
+    AccountMigrationCompletedEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationCompletedEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by SMILE. After SMILE processed the AccountMigrationValidatedEvent and switched over to Billy from Siemens they trigger this event to inform consumers like BIT CSA portal and Salesforce to do the necessary steps for the switchover\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"completedAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration was completed (in epoch millis)\\\\\\"}]}\\",
+    AccountMigrationCompletedEventName: \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\",
+    AccountMigrationRollBackInitiatedEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationRollBackInitiatedEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Migration Service. After T2 it signals that a siemens account migration roll back was initiated. SMILE should change the data master system for the account from Billy to Siemens and inform other system about the result.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"rollBackInitiatedAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration rollback was initiated (in epoch millis)\\\\\\"}]}\\",
+    AccountMigrationRollBackInitiatedEventName: \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\",
+    AccountMigrationRolledBackEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationRolledBackEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by SMILE. As the response to the AccountMigrationRollBackInitiatedEvent, SMILE indicates that mastering system for account data has been restored to be Siemens.As an action to this Billy, BIT CSA portal and Salesforce can do the necessary steps to clean up internal data and switch over to use Siemens data.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"rolledBackAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration was rolled back (in epoch millis)\\\\\\"}]}\\",
+    AccountMigrationRolledBackEventName: \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\",
+    AccountMigrationScheduledEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationScheduledEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Migration Service. At T-2 it signals that a siemens account migration has been scheduled for T0 (effectiveEnrollmentDate).Consumers should do the necessary steps like removing primary card functionality in PAYG account service. If consumers see a new AccountMigrationScheduledEvent with a new flow id then they have to update their internal state with the new flow id since every subsequent message in the migration flow will use the same id\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mpan\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The unique national reference for Meter Point Administration Number\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"supplyStartDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the customer came on supply with Boost (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"scheduledAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration was scheduled (in epoch millis)\\\\\\"}]}\\",
+    AccountMigrationScheduledEventName: \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\",
+    AccountMigrationValidatedEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationValidatedEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Balance Service. At T2 it signals that a siemens balance and transaction history was migrated to the new balance platform and the validation was successful. Billy is ready to be the source for balance and transaction history data. SMILE should change the data master system for the account from Siemens to Billy and inform other system about the result\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"validatedAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migrated balance and transactions were validated (in epoch millis)\\\\\\"}]}\\",
+    AccountMigrationValidatedEventName: \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\",
+    BalanceRetrievedMigrationEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"BalanceRetrievedMigrationEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Migration Service. At T1 signals that a siemens balance and transaction history is available for Billy. Contains details.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mpan\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The unique national reference for Meter Point Administration Number\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"retrievedAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the balance and transaction history was fetched (in epoch millis)\\\\\\"}]}\\",
+    BalanceRetrievedMigrationEventName: \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\",
+    AccountMigrationEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationEvent\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"uk.co.boostpower.support.kafka.messages\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Account migration related events. It describes several flows: 1. Happy path: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationValidatedEvent -> AccountMigrationCompletedEvent 2. Cancel where the migration is about the be restarted: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationCancelledEvent -> Start from the beginning, AccountMigrationScheduledEvent -> AccountMigrationCancelledEvent -> Start from the beginning 3. Rollback: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationValidatedEvent -> AccountMigrationCompletedEvent -> AccountMigrationRollBackInitiatedEvent -> AccountMigrationRolledBackEvent -> Start from the beginning AccountMigrationScheduledEvent generates a flow id which is used in every subsequent migration message to be grouped together\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"event\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationCancelledEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Migration Service. Before T2 signals that a siemens account migration has been cancelled. Migration is about to be restarted for the same account that means a new AccountMigrationScheduledEvent with a new flow id will be sent.Consumers should not react on this in normal case.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Metadata, to be used in each event class\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A globally unique ID for this Kafka message\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"A timestamp for when the event was created (in epoch millis)\\\\\\"}]}},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mpan\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The unique national reference for Meter Point Administration Number\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"cancelledAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration was cancelled (in epoch millis)\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationCompletedEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by SMILE. After SMILE processed the AccountMigrationValidatedEvent and switched over to Billy from Siemens they trigger this event to inform consumers like BIT CSA portal and Salesforce to do the necessary steps for the switchover\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"completedAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration was completed (in epoch millis)\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationRollBackInitiatedEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Migration Service. After T2 it signals that a siemens account migration roll back was initiated. SMILE should change the data master system for the account from Billy to Siemens and inform other system about the result.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"rollBackInitiatedAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration rollback was initiated (in epoch millis)\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationRolledBackEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by SMILE. As the response to the AccountMigrationRollBackInitiatedEvent, SMILE indicates that mastering system for account data has been restored to be Siemens.As an action to this Billy, BIT CSA portal and Salesforce can do the necessary steps to clean up internal data and switch over to use Siemens data.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"rolledBackAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration was rolled back (in epoch millis)\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationScheduledEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Migration Service. At T-2 it signals that a siemens account migration has been scheduled for T0 (effectiveEnrollmentDate).Consumers should do the necessary steps like removing primary card functionality in PAYG account service. If consumers see a new AccountMigrationScheduledEvent with a new flow id then they have to update their internal state with the new flow id since every subsequent message in the migration flow will use the same id\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mpan\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The unique national reference for Meter Point Administration Number\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"supplyStartDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the customer came on supply with Boost (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"scheduledAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migration was scheduled (in epoch millis)\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"AccountMigrationValidatedEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Balance Service. At T2 it signals that a siemens balance and transaction history was migrated to the new balance platform and the validation was successful. Billy is ready to be the source for balance and transaction history data. SMILE should change the data master system for the account from Siemens to Billy and inform other system about the result\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"validatedAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the migrated balance and transactions were validated (in epoch millis)\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"BalanceRetrievedMigrationEvent\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Triggered by Migration Service. At T1 signals that a siemens balance and transaction history is available for Billy. Contains details.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.ovoenergy.kafka.common.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"enrollmentId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Globally unique identifier for the enrollment\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"accountId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mpan\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The unique national reference for Meter Point Administration Number\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"effectiveEnrollmentDate\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The date when the account is going to be enrolled for the new balance platform (in epoch days)\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"retrievedAt\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"},\\\\\\"doc\\\\\\":\\\\\\"The time when the balance and transaction history was fetched (in epoch millis)\\\\\\"}]}]}]}\\",
+    AccountMigrationEventName: \\"uk.co.boostpower.support.kafka.messages.AccountMigrationEvent\\"
+};
+
+export namespace ComOvoenergyKafkaCommonEvent {
+    /**
+     * Metadata, to be used in each event class
+     */
+    export interface EventMetadata {
+        /**
+         * A globally unique ID for this Kafka message
+         */
+        eventId: string;
+        /**
+         * An ID that can be used to link all the requests and Kafka messages in a given transaction. If you already have a trace token from a previous event/request, you should copy it here. If this is the very start of a transaction, you should generate a fresh trace token and put it here. A UUID is suitable
+         */
+        traceToken: string;
+        /**
+         * A timestamp for when the event was created (in epoch millis)
+         */
+        createdAt: Moment;
+    }
+}
+
+export namespace UkCoBoostpowerSupportKafkaMessages {
+    /**
+     * Triggered by Migration Service. Before T2 signals that a siemens account migration has been cancelled. Migration is about to be restarted for the same account that means a new AccountMigrationScheduledEvent with a new flow id will be sent.Consumers should not react on this in normal case.
+     */
+    export interface AccountMigrationCancelledEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The unique national reference for Meter Point Administration Number
+         */
+        mpan: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration was cancelled (in epoch millis)
+         */
+        cancelledAt: Moment;
+    }
+    /**
+     * Triggered by SMILE. After SMILE processed the AccountMigrationValidatedEvent and switched over to Billy from Siemens they trigger this event to inform consumers like BIT CSA portal and Salesforce to do the necessary steps for the switchover
+     */
+    export interface AccountMigrationCompletedEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration was completed (in epoch millis)
+         */
+        completedAt: Moment;
+    }
+    /**
+     * Triggered by Migration Service. After T2 it signals that a siemens account migration roll back was initiated. SMILE should change the data master system for the account from Billy to Siemens and inform other system about the result.
+     */
+    export interface AccountMigrationRollBackInitiatedEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration rollback was initiated (in epoch millis)
+         */
+        rollBackInitiatedAt: Moment;
+    }
+    /**
+     * Triggered by SMILE. As the response to the AccountMigrationRollBackInitiatedEvent, SMILE indicates that mastering system for account data has been restored to be Siemens.As an action to this Billy, BIT CSA portal and Salesforce can do the necessary steps to clean up internal data and switch over to use Siemens data.
+     */
+    export interface AccountMigrationRolledBackEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration was rolled back (in epoch millis)
+         */
+        rolledBackAt: Moment;
+    }
+    /**
+     * Triggered by Migration Service. At T-2 it signals that a siemens account migration has been scheduled for T0 (effectiveEnrollmentDate).Consumers should do the necessary steps like removing primary card functionality in PAYG account service. If consumers see a new AccountMigrationScheduledEvent with a new flow id then they have to update their internal state with the new flow id since every subsequent message in the migration flow will use the same id
+     */
+    export interface AccountMigrationScheduledEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The unique national reference for Meter Point Administration Number
+         */
+        mpan: string;
+        /**
+         * The date when the customer came on supply with Boost (in epoch days)
+         */
+        supplyStartDate: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migration was scheduled (in epoch millis)
+         */
+        scheduledAt: Moment;
+    }
+    /**
+     * Triggered by Balance Service. At T2 it signals that a siemens balance and transaction history was migrated to the new balance platform and the validation was successful. Billy is ready to be the source for balance and transaction history data. SMILE should change the data master system for the account from Siemens to Billy and inform other system about the result
+     */
+    export interface AccountMigrationValidatedEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the migrated balance and transactions were validated (in epoch millis)
+         */
+        validatedAt: Moment;
+    }
+    /**
+     * Triggered by Migration Service. At T1 signals that a siemens balance and transaction history is available for Billy. Contains details.
+     */
+    export interface BalanceRetrievedMigrationEvent {
+        metadata: ComOvoenergyKafkaCommonEvent.EventMetadata;
+        /**
+         * Globally unique identifier for the enrollment
+         */
+        enrollmentId: string;
+        /**
+         * Unique identifier for the customer. GentrackId/SiemensId. Usually 7 digits.
+         */
+        accountId: string;
+        /**
+         * The unique national reference for Meter Point Administration Number
+         */
+        mpan: string;
+        /**
+         * The date when the account is going to be enrolled for the new balance platform (in epoch days)
+         */
+        effectiveEnrollmentDate: string;
+        /**
+         * The time when the balance and transaction history was fetched (in epoch millis)
+         */
+        retrievedAt: Moment;
+    }
+    /**
+     * Account migration related events. It describes several flows: 1. Happy path: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationValidatedEvent -> AccountMigrationCompletedEvent 2. Cancel where the migration is about the be restarted: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationCancelledEvent -> Start from the beginning, AccountMigrationScheduledEvent -> AccountMigrationCancelledEvent -> Start from the beginning 3. Rollback: AccountMigrationScheduledEvent -> BalanceRetrievedMigrationEvent -> AccountMigrationValidatedEvent -> AccountMigrationCompletedEvent -> AccountMigrationRollBackInitiatedEvent -> AccountMigrationRolledBackEvent -> Start from the beginning AccountMigrationScheduledEvent generates a flow id which is used in every subsequent migration message to be grouped together
+     */
+    export interface AccountMigrationEvent {
+        event: {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationCancelledEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationCompletedEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationRollBackInitiatedEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationRolledBackEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationScheduledEvent;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\": UkCoBoostpowerSupportKafkaMessages.AccountMigrationValidatedEvent;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\"?: never;
+        } | {
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCancelledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationCompletedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRollBackInitiatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationRolledBackEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationScheduledEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.AccountMigrationValidatedEvent\\"?: never;
+            \\"uk.co.boostpower.support.kafka.messages.BalanceRetrievedMigrationEvent\\": UkCoBoostpowerSupportKafkaMessages.BalanceRetrievedMigrationEvent;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert ComplexUnionLogicalTypes.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2239,6 +3006,13 @@ export enum ComExampleAvroMyEnum {
 "
 `;
 
+exports[`Avro ts test Should convert EnumWithFullName.avsc successfully using experimental type only namespaces 1`] = `
+"export type AvroType = ComExampleAvroMyEnum;
+
+export type ComExampleAvroMyEnum = \\"ACTIVE\\" | \\"INACTIVE\\";
+"
+`;
+
 exports[`Avro ts test Should convert EnumWithFullName.avsc successfully with default as optional 1`] = `
 "export type AvroType = ComExampleAvroMyEnum;
 
@@ -2278,6 +3052,28 @@ export namespace Namespace {
     }
     export const EpicFailureSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"error\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EpicFailure\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"namespace\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"code\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ErrorCode\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ERROR\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"message\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\";
     export const EpicFailureName = \\"namespace.EpicFailure\\";
+    export interface EpicFailure {
+        code: Namespace.ErrorCode;
+        message: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert EpicError.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type EpicFailure = Namespace.EpicFailure;
+
+export const Namespace = {
+    ErrorCodeSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ErrorCode\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ERROR\\\\\\"]}\\",
+    ErrorCodeName: \\"namespace.ErrorCode\\",
+    EpicFailureSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"error\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EpicFailure\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"namespace\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"code\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ErrorCode\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ERROR\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"message\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    EpicFailureName: \\"namespace.EpicFailure\\"
+};
+
+export namespace Namespace {
+    export type ErrorCode = \\"ERROR\\";
     export interface EpicFailure {
         code: Namespace.ErrorCode;
         message: string;
@@ -2577,6 +3373,160 @@ export namespace MbrSplitM03 {
 "
 `;
 
+exports[`Avro ts test Should convert M03.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type M03 = MbrSplitM03.M03;
+
+export const MbrSplitM03M03 = {
+    ItemsSchema: \\"{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"SHIPPER_REFERENCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"SEND_REASON_CODE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"ACTUAL_READ_DATE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_SERIAL_NUMBER\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_POINT_REFERENCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"PRIME_METER_POINT_REFERENCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"BILLING_INDICATOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"READ_SEQUENCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"READ_REASON_CODE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"READ_TYPE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_READING\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NUMBER_OF_DIALS_OR_DIGITS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_UNCORRECTED_READING\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NUMBER_OF_DIALS_UNCORRECTED\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_CORRECTED_READING\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NUMBER_OF_DIALS_CORRECTED\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"OVERRIDE_VOLUME\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"OVERRIDE_VOLUME_UNITS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"OVERRIDE_REASON\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"BYPASS_STATUS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"COLLAR_STATUS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CAPPED_STATUS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_STATUS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_2\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_3\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_4\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METRIC_IMPERIAL_INDICATOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_CORRECTION_FACTOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_CORRECTION_FACTOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"READING_FACTOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_THROUGH_ZEROS_COUNT\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_THROUGH_ZEROS_COUNT\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METERING_SET_REFERENCE_NUMBER\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CONFIRMATION_REFERENCE_NUMBER\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NON_CYCLIC_TOLERANCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_PULSE_VALUE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_MANUFACTURER_ORG_ID\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_LOCATION_DESCRIPTION\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_LOCATION_CODE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_MODEL\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_SERIAL_NUMBER\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_MECHANISM\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTED_READING_UNITS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"Items\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.m03.m03\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}\\",
+    ItemsName: \\"mbr.split.m03.m03.Items\\"
+};
+
+export const MetaV1 = {
+    MetaV1Schema: \\"{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\",\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"doc\\\\\\":\\\\\\"The url of the parsed Avro Data file from which the record was extracted.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"sourcePath\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"doc\\\\\\":\\\\\\"The md5Hash of the parsed Avro Data file from which the record was extracted.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"md5Hash\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"doc\\\\\\":\\\\\\"The url of the original raw flow file.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"rawSourcePath\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"doc\\\\\\":\\\\\\"The md5Hash of the original raw flow file.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"rawSourceMd5Hash\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"metaV1\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"metaV1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}\\",
+    MetaV1Name: \\"metaV1.metaV1\\"
+};
+
+export const MbrSplitA00 = {
+    ItemsSchema: \\"{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"Organisation_ID\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"flowName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Creation_Date\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Creation_Time\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Generation_Number\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"Items\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.a00\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}\\",
+    ItemsName: \\"mbr.split.a00.Items\\"
+};
+
+export const MbrSplit = {
+    A00Schema: \\"{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"items\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"Organisation_ID\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"flowName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Creation_Date\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Creation_Time\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Generation_Number\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"Items\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.a00\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}}],\\\\\\"name\\\\\\":\\\\\\"A00\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}\\",
+    A00Name: \\"mbr.split.A00\\",
+    Z99Schema: \\"{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"items\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"Record_Count\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"Items\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.z99\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}}],\\\\\\"name\\\\\\":\\\\\\"Z99\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}\\",
+    Z99Name: \\"mbr.split.Z99\\"
+};
+
+export const MbrSplitZ99 = {
+    ItemsSchema: \\"{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"Record_Count\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"Items\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.z99\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}\\",
+    ItemsName: \\"mbr.split.z99.Items\\"
+};
+
+export const MbrSplitM03 = {
+    M03Schema: \\"{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"items\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"SHIPPER_REFERENCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"SEND_REASON_CODE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"ACTUAL_READ_DATE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_SERIAL_NUMBER\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_POINT_REFERENCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"PRIME_METER_POINT_REFERENCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"BILLING_INDICATOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"READ_SEQUENCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"READ_REASON_CODE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"READ_TYPE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_READING\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NUMBER_OF_DIALS_OR_DIGITS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_UNCORRECTED_READING\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NUMBER_OF_DIALS_UNCORRECTED\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_CORRECTED_READING\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NUMBER_OF_DIALS_CORRECTED\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"OVERRIDE_VOLUME\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"OVERRIDE_VOLUME_UNITS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"OVERRIDE_REASON\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"BYPASS_STATUS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"COLLAR_STATUS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CAPPED_STATUS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_STATUS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_2\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_3\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_4\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NOTE_CODE_5\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METRIC_IMPERIAL_INDICATOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_CORRECTION_FACTOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_CORRECTION_FACTOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"READING_FACTOR\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_THROUGH_ZEROS_COUNT\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_THROUGH_ZEROS_COUNT\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METERING_SET_REFERENCE_NUMBER\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CONFIRMATION_REFERENCE_NUMBER\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"NON_CYCLIC_TOLERANCE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_PULSE_VALUE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_MANUFACTURER_ORG_ID\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_LOCATION_DESCRIPTION\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_LOCATION_CODE\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_MODEL\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTOR_SERIAL_NUMBER\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"METER_MECHANISM\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"CORRECTED_READING_UNITS\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"Items\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.m03.m03\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}},{\\\\\\"doc\\\\\\":\\\\\\"the Id of this record. Each record gets assigned a unique Id.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"recordId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\",\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"traceToken\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"doc\\\\\\":\\\\\\"The url of the parsed Avro Data file from which the record was extracted.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"sourcePath\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"doc\\\\\\":\\\\\\"The md5Hash of the parsed Avro Data file from which the record was extracted.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"md5Hash\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"doc\\\\\\":\\\\\\"The url of the original raw flow file.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"rawSourcePath\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"doc\\\\\\":\\\\\\"The md5Hash of the original raw flow file.\\\\\\",\\\\\\"name\\\\\\":\\\\\\"rawSourceMd5Hash\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"metaV1\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"metaV1\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"header\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"items\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"Organisation_ID\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"flowName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Creation_Date\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Creation_Time\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"Generation_Number\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"Items\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.a00\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}}],\\\\\\"name\\\\\\":\\\\\\"A00\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"footer\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"items\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"Record_Count\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"name\\\\\\":\\\\\\"Items\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.z99\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}}],\\\\\\"name\\\\\\":\\\\\\"Z99\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}}],\\\\\\"name\\\\\\":\\\\\\"M03\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"mbr.split.m03\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\"}\\",
+    M03Name: \\"mbr.split.m03.M03\\"
+};
+
+export namespace MbrSplitM03M03 {
+    export interface Items {
+        SHIPPER_REFERENCE: string;
+        SEND_REASON_CODE: string;
+        ACTUAL_READ_DATE: string;
+        METER_SERIAL_NUMBER: string;
+        METER_POINT_REFERENCE: string;
+        PRIME_METER_POINT_REFERENCE: string;
+        BILLING_INDICATOR: string;
+        READ_SEQUENCE: string;
+        READ_REASON_CODE: string;
+        READ_TYPE: string;
+        METER_READING: string;
+        NUMBER_OF_DIALS_OR_DIGITS: string;
+        CORRECTOR_UNCORRECTED_READING: string;
+        NUMBER_OF_DIALS_UNCORRECTED: string;
+        CORRECTOR_CORRECTED_READING: string;
+        NUMBER_OF_DIALS_CORRECTED: string;
+        OVERRIDE_VOLUME: string;
+        OVERRIDE_VOLUME_UNITS: string;
+        OVERRIDE_REASON: string;
+        BYPASS_STATUS: string;
+        COLLAR_STATUS: string;
+        CAPPED_STATUS: string;
+        CORRECTOR_STATUS: string;
+        NOTE_CODE_1: string;
+        NOTE_CODE_2: string;
+        NOTE_CODE_3: string;
+        NOTE_CODE_4: string;
+        NOTE_CODE_5: string;
+        METRIC_IMPERIAL_INDICATOR: string;
+        METER_CORRECTION_FACTOR: string;
+        CORRECTOR_CORRECTION_FACTOR: string;
+        READING_FACTOR: string;
+        METER_THROUGH_ZEROS_COUNT: string;
+        CORRECTOR_THROUGH_ZEROS_COUNT: string;
+        METERING_SET_REFERENCE_NUMBER: string;
+        CONFIRMATION_REFERENCE_NUMBER: string;
+        NON_CYCLIC_TOLERANCE: string;
+        METER_PULSE_VALUE: string;
+        METER_MANUFACTURER_ORG_ID: string;
+        METER_LOCATION_DESCRIPTION: string;
+        METER_LOCATION_CODE: string;
+        METER_MODEL: string;
+        CORRECTOR_SERIAL_NUMBER: string;
+        METER_MECHANISM: string;
+        CORRECTED_READING_UNITS: string;
+    }
+}
+
+export namespace MetaV1 {
+    export interface MetaV1 {
+        eventId: string;
+        createdAt: number;
+        traceToken: string;
+        /**
+         * The url of the parsed Avro Data file from which the record was extracted.
+         */
+        sourcePath: string;
+        /**
+         * The md5Hash of the parsed Avro Data file from which the record was extracted.
+         */
+        md5Hash: string;
+        /**
+         * The url of the original raw flow file.
+         */
+        rawSourcePath: string;
+        /**
+         * The md5Hash of the original raw flow file.
+         */
+        rawSourceMd5Hash: string;
+    }
+}
+
+export namespace MbrSplitA00 {
+    export interface Items {
+        Organisation_ID: string;
+        flowName: string;
+        Creation_Date: string;
+        Creation_Time: string;
+        Generation_Number: string;
+    }
+}
+
+export namespace MbrSplit {
+    export interface A00 {
+        groupName: string;
+        items: MbrSplitA00.Items;
+    }
+    export interface Z99 {
+        groupName: string;
+        items: MbrSplitZ99.Items;
+    }
+}
+
+export namespace MbrSplitZ99 {
+    export interface Items {
+        Record_Count: string;
+    }
+}
+
+export namespace MbrSplitM03 {
+    export interface M03 {
+        groupName: string;
+        items: MbrSplitM03M03.Items;
+        /**
+         * the Id of this record. Each record gets assigned a unique Id.
+         */
+        recordId: string;
+        metadata: MetaV1.MetaV1;
+        header: MbrSplit.A00;
+        footer: MbrSplit.Z99;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert M03.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2809,6 +3759,57 @@ export namespace ComAvroExample {
 "
 `;
 
+exports[`Avro ts test Should convert NestedRecordNamespace.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type NestRecordEvent = ComAvroExample.NestRecordEvent;
+
+export const ComAvroExample = {
+    Level2RecordSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level2Record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    Level2RecordName: \\"com.avro.example.Level2Record\\",
+    Level2SiblingSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level2Sibling\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    Level2SiblingName: \\"com.avro.example.Level2Sibling\\",
+    Level1RecordSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level1Record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"child\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level2Record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level2Sibling\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}]}]}\\",
+    Level1RecordName: \\"com.avro.example.Level1Record\\",
+    Level1SiblingSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level1Sibling\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    Level1SiblingName: \\"com.avro.example.Level1Sibling\\",
+    NestRecordEventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"NestRecordEvent\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.avro.example\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"event\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level1Record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"child\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level2Record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level2Sibling\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}]}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Level1Sibling\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}]}]}\\",
+    NestRecordEventName: \\"com.avro.example.NestRecordEvent\\"
+};
+
+export namespace ComAvroExample {
+    export interface Level2Record {
+        id: string;
+    }
+    export interface Level2Sibling {
+        id: string;
+    }
+    export interface Level1Record {
+        id: string;
+        child: {
+            \\"com.avro.example.Level2Record\\": ComAvroExample.Level2Record;
+            \\"com.avro.example.Level2Sibling\\"?: never;
+        } | {
+            \\"com.avro.example.Level2Record\\"?: never;
+            \\"com.avro.example.Level2Sibling\\": ComAvroExample.Level2Sibling;
+        };
+    }
+    export interface Level1Sibling {
+        id: string;
+    }
+    export interface NestRecordEvent {
+        event: {
+            \\"com.avro.example.Level1Record\\": ComAvroExample.Level1Record;
+            \\"com.avro.example.Level1Sibling\\"?: never;
+        } | {
+            \\"com.avro.example.Level1Record\\"?: never;
+            \\"com.avro.example.Level1Sibling\\": ComAvroExample.Level1Sibling;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert NestedRecordNamespace.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -2924,6 +3925,52 @@ export namespace ComExampleAvro {
     }
     export const EventSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Event\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"field\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FieldTypeA\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"nested\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"name\\\\\\":\\\\\\"NestedFieldType\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FieldTypeB\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]},\\\\\\"com.example.avro.NestedFieldType\\\\\\"]}]}\\";
     export const EventName = \\"com.example.avro.Event\\";
+    export interface Event {
+        field: {
+            \\"com.example.avro.FieldTypeA\\": ComExampleAvro.FieldTypeA;
+            \\"com.example.avro.FieldTypeB\\"?: never;
+            \\"com.example.avro.NestedFieldType\\"?: never;
+        } | {
+            \\"com.example.avro.FieldTypeA\\"?: never;
+            \\"com.example.avro.FieldTypeB\\": ComExampleAvro.FieldTypeB;
+            \\"com.example.avro.NestedFieldType\\"?: never;
+        } | {
+            \\"com.example.avro.FieldTypeA\\"?: never;
+            \\"com.example.avro.FieldTypeB\\"?: never;
+            \\"com.example.avro.NestedFieldType\\": ComExampleAvro.NestedFieldType;
+        };
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert NestedWrappedType.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type Event = ComExampleAvro.Event;
+
+export const ComExampleAvro = {
+    NestedFieldTypeSchema: \\"{\\\\\\"name\\\\\\":\\\\\\"NestedFieldType\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}],\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\"}\\",
+    NestedFieldTypeName: \\"com.example.avro.NestedFieldType\\",
+    FieldTypeASchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FieldTypeA\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"nested\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"name\\\\\\":\\\\\\"NestedFieldType\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}}]}\\",
+    FieldTypeAName: \\"com.example.avro.FieldTypeA\\",
+    FieldTypeBSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FieldTypeB\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    FieldTypeBName: \\"com.example.avro.FieldTypeB\\",
+    EventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Event\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"field\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FieldTypeA\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"nested\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"name\\\\\\":\\\\\\"NestedFieldType\\\\\\",\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FieldTypeB\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]},\\\\\\"com.example.avro.NestedFieldType\\\\\\"]}]}\\",
+    EventName: \\"com.example.avro.Event\\"
+};
+
+export namespace ComExampleAvro {
+    export interface NestedFieldType {
+        id: string;
+    }
+    export interface FieldTypeA {
+        id: string;
+        nested: ComExampleAvro.NestedFieldType;
+    }
+    export interface FieldTypeB {
+        id: string;
+    }
     export interface Event {
         field: {
             \\"com.example.avro.FieldTypeA\\": ComExampleAvro.FieldTypeA;
@@ -3086,6 +4133,59 @@ export namespace ComOvoenergyKafkaTestEvent {
 "
 `;
 
+exports[`Avro ts test Should convert NullableWrappedUnion.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type Test = ComOvoenergyKafkaTestEvent.Test;
+
+export const ComOvoenergyKafkaTestEvent = {
+    ASchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"A\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"foo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"bar\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"}}]}\\",
+    AName: \\"com.ovoenergy.kafka.test.event.A\\",
+    BSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"B\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"fuzz\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":true}]}\\",
+    BName: \\"com.ovoenergy.kafka.test.event.B\\",
+    CSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"C\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"foo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"bar\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"}}]}\\",
+    CName: \\"com.ovoenergy.kafka.test.event.C\\",
+    TestSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"test\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.ovoenergy.kafka.test.event\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"event\\\\\\",\\\\\\"default\\\\\\":\\\\\\"null\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"A\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"foo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"bar\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"}}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"B\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"fuzz\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":true}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"C\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"foo\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"bar\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"int\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"date\\\\\\"}}]}]}]}\\",
+    TestName: \\"com.ovoenergy.kafka.test.event.test\\"
+};
+
+export namespace ComOvoenergyKafkaTestEvent {
+    export interface A {
+        foo: string;
+        bar: string;
+    }
+    export interface B {
+        /**
+         * Default: true
+         */
+        fuzz: boolean;
+    }
+    export interface C {
+        foo: string;
+        bar: string;
+    }
+    export interface Test {
+        /**
+         * Default: \\"null\\"
+         */
+        event: null | {
+            \\"com.ovoenergy.kafka.test.event.A\\": ComOvoenergyKafkaTestEvent.A;
+            \\"com.ovoenergy.kafka.test.event.B\\"?: never;
+            \\"com.ovoenergy.kafka.test.event.C\\"?: never;
+        } | {
+            \\"com.ovoenergy.kafka.test.event.A\\"?: never;
+            \\"com.ovoenergy.kafka.test.event.B\\": ComOvoenergyKafkaTestEvent.B;
+            \\"com.ovoenergy.kafka.test.event.C\\"?: never;
+        } | {
+            \\"com.ovoenergy.kafka.test.event.A\\"?: never;
+            \\"com.ovoenergy.kafka.test.event.B\\"?: never;
+            \\"com.ovoenergy.kafka.test.event.C\\": ComOvoenergyKafkaTestEvent.C;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert NullableWrappedUnion.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -3188,6 +4288,35 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithDefault.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type RecordWithDefault = ComExampleAvro.RecordWithDefault;
+
+export const ComExampleAvro = {
+    NoNeedForNamespaceSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"NoNeedForNamespace\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A fictitious id\\\\\\"}]}\\",
+    NoNeedForNamespaceName: \\"com.example.avro.NoNeedForNamespace\\",
+    RecordWithDefaultSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"RecordWithDefault\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"pleaseNoNamespace\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"NoNeedForNamespace\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A fictitious id\\\\\\"}]}],\\\\\\"default\\\\\\":null}]}\\",
+    RecordWithDefaultName: \\"com.example.avro.RecordWithDefault\\"
+};
+
+export namespace ComExampleAvro {
+    export interface NoNeedForNamespace {
+        /**
+         * A fictitious id
+         */
+        id: string;
+    }
+    export interface RecordWithDefault {
+        /**
+         * Default: null
+         */
+        pleaseNoNamespace: null | ComExampleAvro.NoNeedForNamespace;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithDefault.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -3249,6 +4378,36 @@ export type CreateUser = MyNamespaceMessages.CreateUser;
 export namespace MyNamespaceMessages {
     export const CreateUserSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"CreateUser\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"my.namespace.messages\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"uuid\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"firstname\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"string\\\\\\",\\\\\\"null\\\\\\"],\\\\\\"default\\\\\\":\\\\\\"John\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"lastname\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"email\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"john.doe@example.com\\\\\\"}]}\\";
     export const CreateUserName = \\"my.namespace.messages.CreateUser\\";
+    export interface CreateUser {
+        userId: string;
+        /**
+         * Default: \\"John\\"
+         */
+        firstname: string | null;
+        /**
+         * Default: null
+         */
+        lastname: null | string;
+        /**
+         * Default: \\"john.doe@example.com\\"
+         */
+        email: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithDefaults.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type CreateUser = MyNamespaceMessages.CreateUser;
+
+export const MyNamespaceMessages = {
+    CreateUserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"CreateUser\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"my.namespace.messages\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"uuid\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"firstname\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"string\\\\\\",\\\\\\"null\\\\\\"],\\\\\\"default\\\\\\":\\\\\\"John\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"lastname\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"email\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"john.doe@example.com\\\\\\"}]}\\",
+    CreateUserName: \\"my.namespace.messages.CreateUser\\"
+};
+
+export namespace MyNamespaceMessages {
     export interface CreateUser {
         userId: string;
         /**
@@ -3365,6 +4524,58 @@ export namespace ComExampleAvro {
     }
     export const UserSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Indicator of whether this authorization is currently active, or has been revoked\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ACTIVE\\\\\\",\\\\\\"INACTIVE\\\\\\"]}}]}\\";
     export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        /**
+         * Indicator of whether this authorization is currently active, or has been revoked
+         */
+        status: ComExampleAvro.Status;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithEnum.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export const ComExampleAvro = {
+    StatusSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ACTIVE\\\\\\",\\\\\\"INACTIVE\\\\\\"]}\\",
+    StatusName: \\"com.example.avro.status\\",
+    UserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Indicator of whether this authorization is currently active, or has been revoked\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"ACTIVE\\\\\\",\\\\\\"INACTIVE\\\\\\"]}}]}\\",
+    UserName: \\"com.example.avro.User\\"
+};
+
+export namespace ComExampleAvro {
+    /**
+     * * \`PENDING\`: the user has started authorizing, but not yet finished
+     * * \`ACTIVE\`: the token should work
+     * * \`DENIED\`: the user declined the authorization
+     * * \`EXPIRED\`: the token used to work, but now it doesn't
+     * * \`REVOKED\`: the user has explicitly revoked the token
+     */
+    export type Status = \\"ACTIVE\\" | \\"INACTIVE\\";
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
      *
@@ -3565,6 +4776,69 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithInterface.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export const ComExampleAvro = {
+    EmailAddressSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EmailAddress\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores details about an email address that a user has associated with their account.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The email address, e.g. \`foo@example.com\`\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"verified\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"true if the user has clicked the link in a confirmation email to this address.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":false},{\\\\\\"name\\\\\\":\\\\\\"dateAdded\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the email address was added to the account.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"}]}\\",
+    EmailAddressName: \\"com.example.avro.EmailAddress\\",
+    UserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"emailAddresses\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"All email addresses on the user's account\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EmailAddress\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores details about an email address that a user has associated with their account.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The email address, e.g. \`foo@example.com\`\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"verified\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"true if the user has clicked the link in a confirmation email to this address.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":false},{\\\\\\"name\\\\\\":\\\\\\"dateAdded\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the email address was added to the account.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"}]}}}]}\\",
+    UserName: \\"com.example.avro.User\\"
+};
+
+export namespace ComExampleAvro {
+    /**
+     * Stores details about an email address that a user has associated with their account.
+     */
+    export interface EmailAddress {
+        /**
+         * The email address, e.g. \`foo@example.com\`
+         */
+        address: string;
+        /**
+         * true if the user has clicked the link in a confirmation email to this address.
+         *
+         * Default: false
+         */
+        verified: boolean;
+        /**
+         * Timestamp (milliseconds since epoch) when the email address was added to the account.
+         */
+        dateAdded: number;
+    }
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        /**
+         * All email addresses on the user's account
+         */
+        emailAddresses: ComExampleAvro.EmailAddress[];
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithInterface.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -3683,6 +4957,38 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Moment } from \\"moment\\";
+
+export type Event = ComExampleAvro.Event;
+
+export const ComExampleAvro = {
+    EventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Event\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"createdAt\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A timestamp for when the event was created (in epoch millis)\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"timestamp-millis\\\\\\"}}]}\\",
+    EventName: \\"com.example.avro.Event\\"
+};
+
+export namespace ComExampleAvro {
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface Event {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * A timestamp for when the event was created (in epoch millis)
+         */
+        createdAt: Moment;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithLogicalTypes.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -3755,6 +5061,42 @@ export type Event = ComExampleAvro.Event;
 export namespace ComExampleAvro {
     export const EventSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Event\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"decimalValue\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A Decimal that we need a library for\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"decimal\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"anotherDecimal\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Another decimal to make sure we don't add the import more than once\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"decimal\\\\\\"}}]}\\";
     export const EventName = \\"com.example.avro.Event\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface Event {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * A Decimal that we need a library for
+         */
+        decimalValue: Decimal;
+        /**
+         * Another decimal to make sure we don't add the import more than once
+         */
+        anotherDecimal: Decimal;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithLogicalTypesImport.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Decimal } from \\"decimal.js\\";
+
+export type Event = ComExampleAvro.Event;
+
+export const ComExampleAvro = {
+    EventSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Event\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"decimalValue\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A Decimal that we need a library for\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"decimal\\\\\\"}},{\\\\\\"name\\\\\\":\\\\\\"anotherDecimal\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Another decimal to make sure we don't add the import more than once\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"logicalType\\\\\\":\\\\\\"decimal\\\\\\"}}]}\\",
+    EventName: \\"com.example.avro.Event\\"
+};
+
+export namespace ComExampleAvro {
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
      *
@@ -3897,6 +5239,52 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithMap.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export const ComExampleAvro = {
+    FooSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Foo\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"label\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    FooName: \\"com.example.avro.Foo\\",
+    UserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"mapField\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"map\\\\\\",\\\\\\"values\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Foo\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"label\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}}}]}\\",
+    UserName: \\"com.example.avro.User\\"
+};
+
+export namespace ComExampleAvro {
+    export interface Foo {
+        label: string;
+    }
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        mapField: {
+            [index: string]: ComExampleAvro.Foo;
+        };
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithMap.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -3970,6 +5358,24 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert RecordWithNamedBooleanType.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type RecordWithNamedStringType = ComExampleAvro.RecordWithNamedStringType;
+
+export const ComExampleAvro = {
+    RecordWithNamedStringTypeSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"RecordWithNamedStringType\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"pleaseNoNamespace\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"some.metadata.field\\\\\\":\\\\\\"dontCare\\\\\\"}}]}\\",
+    RecordWithNamedStringTypeName: \\"com.example.avro.RecordWithNamedStringType\\"
+};
+
+export namespace ComExampleAvro {
+    export interface RecordWithNamedStringType {
+        pleaseNoNamespace: boolean;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert RecordWithNamedBooleanType.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -4008,6 +5414,24 @@ export type RecordWithNamedStringType = ComExampleAvro.RecordWithNamedStringType
 export namespace ComExampleAvro {
     export const RecordWithNamedStringTypeSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"RecordWithNamedStringType\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"pleaseNoNamespace\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"some.metadata.field\\\\\\":\\\\\\"dontCare\\\\\\"}}]}\\";
     export const RecordWithNamedStringTypeName = \\"com.example.avro.RecordWithNamedStringType\\";
+    export interface RecordWithNamedStringType {
+        pleaseNoNamespace: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithNamedStringType.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type RecordWithNamedStringType = ComExampleAvro.RecordWithNamedStringType;
+
+export const ComExampleAvro = {
+    RecordWithNamedStringTypeSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"RecordWithNamedStringType\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"pleaseNoNamespace\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"some.metadata.field\\\\\\":\\\\\\"dontCare\\\\\\"}}]}\\",
+    RecordWithNamedStringTypeName: \\"com.example.avro.RecordWithNamedStringType\\"
+};
+
+export namespace ComExampleAvro {
     export interface RecordWithNamedStringType {
         pleaseNoNamespace: string;
     }
@@ -4077,6 +5501,48 @@ export type User = ComExampleAvro.User;
 export namespace ComExampleAvro {
     export const UserSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"unionType\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}]}\\";
     export const UserName = \\"com.example.avro.User\\";
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        /**
+         * Default: null
+         */
+        unionType: null | string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert RecordWithUnion.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export const ComExampleAvro = {
+    UserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"unionType\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"],\\\\\\"default\\\\\\":null}]}\\",
+    UserName: \\"com.example.avro.User\\"
+};
+
+export namespace ComExampleAvro {
     /**
      * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
      *
@@ -4217,6 +5683,44 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert SimpleRecord.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export const ComExampleAvro = {
+    UserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"}]}\\",
+    UserName: \\"com.example.avro.User\\"
+};
+
+export namespace ComExampleAvro {
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert SimpleRecord.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -4316,6 +5820,48 @@ export namespace ComExampleAvro {
     }
     export const CreationSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Creation\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.example.avro.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"creationId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\";
     export const CreationName = \\"com.example.avro.Creation\\";
+    export interface Creation {
+        metadata: ComExampleAvroEvent.EventMetadata;
+        creationId: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert TopLevelUnion.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type AvroType = {
+    \\"com.example.avro.Cancelled\\": ComExampleAvro.Cancelled;
+    \\"com.example.avro.Creation\\"?: never;
+} | {
+    \\"com.example.avro.Cancelled\\"?: never;
+    \\"com.example.avro.Creation\\": ComExampleAvro.Creation;
+};
+
+export const ComExampleAvroEvent = {
+    EventMetadataSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro.event\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    EventMetadataName: \\"com.example.avro.event.EventMetadata\\"
+};
+
+export const ComExampleAvro = {
+    CancelledSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Cancelled\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EventMetadata\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro.event\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"eventId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}},{\\\\\\"name\\\\\\":\\\\\\"CancellationId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    CancelledName: \\"com.example.avro.Cancelled\\",
+    CreationSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Creation\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"metadata\\\\\\",\\\\\\"type\\\\\\":\\\\\\"com.example.avro.event.EventMetadata\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"creationId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    CreationName: \\"com.example.avro.Creation\\"
+};
+
+export namespace ComExampleAvroEvent {
+    export interface EventMetadata {
+        eventId: string;
+    }
+}
+
+export namespace ComExampleAvro {
+    export interface Cancelled {
+        metadata: ComExampleAvroEvent.EventMetadata;
+        CancellationId: string;
+    }
     export interface Creation {
         metadata: ComExampleAvroEvent.EventMetadata;
         creationId: string;
@@ -4480,6 +6026,77 @@ export namespace ComExampleAvro {
     }
     export const TradeCollectionSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeCollection\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"producerId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"exchange\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"market\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"trades\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Trade\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"price\\\\\\",\\\\\\"type\\\\\\":\\\\\\"double\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"amount\\\\\\",\\\\\\"type\\\\\\":\\\\\\"double\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"datetime\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"timestamp\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"type\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeType\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Market\\\\\\",\\\\\\"Limit\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"side\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeDirection\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Buy\\\\\\",\\\\\\"Sell\\\\\\"]}],\\\\\\"default\\\\\\":null}]}},\\\\\\"default\\\\\\":[]}]}\\";
     export const TradeCollectionName = \\"com.example.avro.TradeCollection\\";
+    export interface TradeCollection {
+        /**
+         * Default: \\"\\"
+         */
+        producerId: string;
+        /**
+         * Default: \\"\\"
+         */
+        exchange: string;
+        /**
+         * Default: \\"\\"
+         */
+        market: string;
+        /**
+         * Default: []
+         */
+        trades: ComExampleAvro.Trade[];
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert TradeCollection.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type TradeCollection = ComExampleAvro.TradeCollection;
+
+export const ComExampleAvro = {
+    TradeTypeSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeType\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Market\\\\\\",\\\\\\"Limit\\\\\\"]}\\",
+    TradeTypeName: \\"com.example.avro.TradeType\\",
+    TradeDirectionSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeDirection\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Buy\\\\\\",\\\\\\"Sell\\\\\\"]}\\",
+    TradeDirectionName: \\"com.example.avro.TradeDirection\\",
+    TradeSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Trade\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"price\\\\\\",\\\\\\"type\\\\\\":\\\\\\"double\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"amount\\\\\\",\\\\\\"type\\\\\\":\\\\\\"double\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"datetime\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"timestamp\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"type\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeType\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Market\\\\\\",\\\\\\"Limit\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"side\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeDirection\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Buy\\\\\\",\\\\\\"Sell\\\\\\"]}],\\\\\\"default\\\\\\":null}]}\\",
+    TradeName: \\"com.example.avro.Trade\\",
+    TradeCollectionSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeCollection\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"producerId\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"exchange\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"market\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"trades\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Trade\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"price\\\\\\",\\\\\\"type\\\\\\":\\\\\\"double\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"amount\\\\\\",\\\\\\"type\\\\\\":\\\\\\"double\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"datetime\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"timestamp\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\",\\\\\\"default\\\\\\":0},{\\\\\\"name\\\\\\":\\\\\\"type\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeType\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Market\\\\\\",\\\\\\"Limit\\\\\\"]}],\\\\\\"default\\\\\\":null},{\\\\\\"name\\\\\\":\\\\\\"side\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TradeDirection\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"Buy\\\\\\",\\\\\\"Sell\\\\\\"]}],\\\\\\"default\\\\\\":null}]}},\\\\\\"default\\\\\\":[]}]}\\",
+    TradeCollectionName: \\"com.example.avro.TradeCollection\\"
+};
+
+export namespace ComExampleAvro {
+    export type TradeType = \\"Market\\" | \\"Limit\\";
+    export type TradeDirection = \\"Buy\\" | \\"Sell\\";
+    export interface Trade {
+        /**
+         * Default: \\"\\"
+         */
+        id: string;
+        /**
+         * Default: 0
+         */
+        price: number;
+        /**
+         * Default: 0
+         */
+        amount: number;
+        /**
+         * Default: \\"\\"
+         */
+        datetime: string;
+        /**
+         * Default: 0
+         */
+        timestamp: number;
+        /**
+         * Default: null
+         */
+        type: null | ComExampleAvro.TradeType;
+        /**
+         * Default: null
+         */
+        side: null | ComExampleAvro.TradeDirection;
+    }
     export interface TradeCollection {
         /**
          * Default: \\"\\"
@@ -4687,6 +6304,77 @@ export namespace ComExampleKafkaFlowsEventFlowSplitTrfPreNexus {
     }
     export const TrfPreNexusSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TrfPreNexus\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.flows.event.flow.split.trfPreNexus\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"data\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Deleted\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.flows.event.flow\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This type indicates that the data has been deleted according to the data retention policy.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"deleteReason\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Additional information about reason behind the delete event\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FlowContents\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"record\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"LapsedConfirmationDets\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"lapsedConfirmationDets\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TransferOfOwnership\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"transferOfOwnership\\\\\\"}]}],\\\\\\"doc\\\\\\":\\\\\\"The split flow record.\\\\\\"}]}]}]}\\";
     export const TrfPreNexusName = \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TrfPreNexus\\";
+    export interface TrfPreNexus {
+        data: {
+            \\"com.example.kafka.flows.event.flow.Deleted\\": ComExampleKafkaFlowsEventFlow.Deleted;
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.FlowContents\\"?: never;
+        } | {
+            \\"com.example.kafka.flows.event.flow.Deleted\\"?: never;
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.FlowContents\\": ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.FlowContents;
+        };
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert TrfPreNexus.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type TrfPreNexus = ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.TrfPreNexus;
+
+export const ComExampleKafkaFlowsEventFlow = {
+    DeletedSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Deleted\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.flows.event.flow\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This type indicates that the data has been deleted according to the data retention policy.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"deleteReason\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Additional information about reason behind the delete event\\\\\\"}]}\\",
+    DeletedName: \\"com.example.kafka.flows.event.flow.Deleted\\"
+};
+
+export const ComExampleKafkaFlowsEventFlowSplitTrfPreNexus = {
+    LapsedConfirmationDetsSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"LapsedConfirmationDets\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"lapsedConfirmationDets\\\\\\"}]}\\",
+    LapsedConfirmationDetsName: \\"com.example.kafka.flows.event.flow.split.trfPreNexus.LapsedConfirmationDets\\",
+    TransferOfOwnershipSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TransferOfOwnership\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"transferOfOwnership\\\\\\"}]}\\",
+    TransferOfOwnershipName: \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TransferOfOwnership\\",
+    FlowContentsSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FlowContents\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"record\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"LapsedConfirmationDets\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"lapsedConfirmationDets\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TransferOfOwnership\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"transferOfOwnership\\\\\\"}]}],\\\\\\"doc\\\\\\":\\\\\\"The split flow record.\\\\\\"}]}\\",
+    FlowContentsName: \\"com.example.kafka.flows.event.flow.split.trfPreNexus.FlowContents\\",
+    TrfPreNexusSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TrfPreNexus\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.flows.event.flow.split.trfPreNexus\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"data\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"Deleted\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.kafka.flows.event.flow\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This type indicates that the data has been deleted according to the data retention policy.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"deleteReason\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Additional information about reason behind the delete event\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"FlowContents\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"record\\\\\\",\\\\\\"type\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"LapsedConfirmationDets\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"lapsedConfirmationDets\\\\\\"}]},{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TransferOfOwnership\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"groupName\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"default\\\\\\":\\\\\\"transferOfOwnership\\\\\\"}]}],\\\\\\"doc\\\\\\":\\\\\\"The split flow record.\\\\\\"}]}]}]}\\",
+    TrfPreNexusName: \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TrfPreNexus\\"
+};
+
+export namespace ComExampleKafkaFlowsEventFlow {
+    /**
+     * This type indicates that the data has been deleted according to the data retention policy.
+     */
+    export interface Deleted {
+        /**
+         * Additional information about reason behind the delete event
+         */
+        deleteReason: string;
+    }
+}
+
+export namespace ComExampleKafkaFlowsEventFlowSplitTrfPreNexus {
+    export interface LapsedConfirmationDets {
+        /**
+         * Default: \\"lapsedConfirmationDets\\"
+         */
+        groupName: string;
+    }
+    export interface TransferOfOwnership {
+        /**
+         * Default: \\"transferOfOwnership\\"
+         */
+        groupName: string;
+    }
+    export interface FlowContents {
+        /**
+         * The split flow record.
+         */
+        record: {
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.LapsedConfirmationDets\\": ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.LapsedConfirmationDets;
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TransferOfOwnership\\"?: never;
+        } | {
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.LapsedConfirmationDets\\"?: never;
+            \\"com.example.kafka.flows.event.flow.split.trfPreNexus.TransferOfOwnership\\": ComExampleKafkaFlowsEventFlowSplitTrfPreNexus.TransferOfOwnership;
+        };
+    }
     export interface TrfPreNexus {
         data: {
             \\"com.example.kafka.flows.event.flow.Deleted\\": ComExampleKafkaFlowsEventFlow.Deleted;
@@ -5077,6 +6765,159 @@ export namespace ComExampleAvro {
 "
 `;
 
+exports[`Avro ts test Should convert User.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type User = ComExampleAvro.User;
+
+export const ComExampleAvro = {
+    EmailAddressSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EmailAddress\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores details about an email address that a user has associated with their account.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The email address, e.g. \`foo@example.com\`\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"verified\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"true if the user has clicked the link in a confirmation email to this address.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":false},{\\\\\\"name\\\\\\":\\\\\\"dateAdded\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the email address was added to the account.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"dateBounced\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when an email sent to this address last bounced. Reset to null when the address no longer bounces.\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"long\\\\\\"]}]}\\",
+    EmailAddressName: \\"com.example.avro.EmailAddress\\",
+    OAuthStatusSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"OAuthStatus\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"PENDING\\\\\\",\\\\\\"ACTIVE\\\\\\",\\\\\\"DENIED\\\\\\",\\\\\\"EXPIRED\\\\\\",\\\\\\"REVOKED\\\\\\"]}\\",
+    OAuthStatusName: \\"com.example.avro.OAuthStatus\\",
+    TwitterAccountSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TwitterAccount\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores access credentials for one Twitter account, as granted to us by the user by OAuth.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Indicator of whether this authorization is currently active, or has been revoked\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"OAuthStatus\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"PENDING\\\\\\",\\\\\\"ACTIVE\\\\\\",\\\\\\"DENIED\\\\\\",\\\\\\"EXPIRED\\\\\\",\\\\\\"REVOKED\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Twitter's numeric ID for this user\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"screenName\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The twitter username for this account (can be changed by the user)\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"oauthToken\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The OAuth token for this Twitter account\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"oauthTokenSecret\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The OAuth secret, used for signing requests on behalf of this Twitter account. \`null\` whilst the OAuth flow is not yet complete.\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"dateAuthorized\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user last authorized this Twitter account\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"}]}\\",
+    TwitterAccountName: \\"com.example.avro.TwitterAccount\\",
+    ToDoStatusSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ToDoStatus\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`HIDDEN\`: not currently visible, e.g. because it becomes actionable in future\\\\\\\\n* \`ACTIONABLE\`: appears in the current to-do list\\\\\\\\n* \`DONE\`: marked as done, but still appears in the list\\\\\\\\n* \`ARCHIVED\`: marked as done and no longer visible\\\\\\\\n* \`DELETED\`: not done and removed from list (preserved for undo purposes)\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"HIDDEN\\\\\\",\\\\\\"ACTIONABLE\\\\\\",\\\\\\"DONE\\\\\\",\\\\\\"ARCHIVED\\\\\\",\\\\\\"DELETED\\\\\\"]}\\",
+    ToDoStatusName: \\"com.example.avro.ToDoStatus\\",
+    ToDoItemSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ToDoItem\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A record is one node in a To-Do item tree (every record can contain nested sub-records).\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"User-selected state for this item (e.g. whether or not it is marked as done)\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ToDoStatus\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`HIDDEN\`: not currently visible, e.g. because it becomes actionable in future\\\\\\\\n* \`ACTIONABLE\`: appears in the current to-do list\\\\\\\\n* \`DONE\`: marked as done, but still appears in the list\\\\\\\\n* \`ARCHIVED\`: marked as done and no longer visible\\\\\\\\n* \`DELETED\`: not done and removed from list (preserved for undo purposes)\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"HIDDEN\\\\\\",\\\\\\"ACTIONABLE\\\\\\",\\\\\\"DONE\\\\\\",\\\\\\"ARCHIVED\\\\\\",\\\\\\"DELETED\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"title\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"One-line summary of the item\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"description\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Detailed description (may contain HTML markup)\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"snoozeDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) at which the item should go from \`HIDDEN\` to \`ACTIONABLE\` status\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"long\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"subItems\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"List of children of this to-do tree node\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":\\\\\\"ToDoItem\\\\\\"}}]}\\",
+    ToDoItemName: \\"com.example.avro.ToDoItem\\",
+    UserSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"User\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.example.avro\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.\\\\\\\\n\\\\\\\\nNote this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"id\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"System-assigned numeric user ID. Cannot be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"int\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"username\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The username chosen by the user. Can be changed by the user.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"passwordHash\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"signupDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user signed up\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"emailAddresses\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"All email addresses on the user's account\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"EmailAddress\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores details about an email address that a user has associated with their account.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"address\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The email address, e.g. \`foo@example.com\`\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"verified\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"true if the user has clicked the link in a confirmation email to this address.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"boolean\\\\\\",\\\\\\"default\\\\\\":false},{\\\\\\"name\\\\\\":\\\\\\"dateAdded\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the email address was added to the account.\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"dateBounced\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when an email sent to this address last bounced. Reset to null when the address no longer bounces.\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"long\\\\\\"]}]}}},{\\\\\\"name\\\\\\":\\\\\\"twitterAccounts\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"All Twitter accounts that the user has OAuthed\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"TwitterAccount\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Stores access credentials for one Twitter account, as granted to us by the user by OAuth.\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Indicator of whether this authorization is currently active, or has been revoked\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"OAuthStatus\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`PENDING\`: the user has started authorizing, but not yet finished\\\\\\\\n* \`ACTIVE\`: the token should work\\\\\\\\n* \`DENIED\`: the user declined the authorization\\\\\\\\n* \`EXPIRED\`: the token used to work, but now it doesn't\\\\\\\\n* \`REVOKED\`: the user has explicitly revoked the token\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"PENDING\\\\\\",\\\\\\"ACTIVE\\\\\\",\\\\\\"DENIED\\\\\\",\\\\\\"EXPIRED\\\\\\",\\\\\\"REVOKED\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Twitter's numeric ID for this user\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"screenName\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The twitter username for this account (can be changed by the user)\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"oauthToken\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The OAuth token for this Twitter account\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"oauthTokenSecret\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The OAuth secret, used for signing requests on behalf of this Twitter account. \`null\` whilst the OAuth flow is not yet complete.\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"dateAuthorized\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) when the user last authorized this Twitter account\\\\\\",\\\\\\"type\\\\\\":\\\\\\"long\\\\\\"}]}}},{\\\\\\"name\\\\\\":\\\\\\"toDoItems\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"The top-level items in the user's to-do list\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ToDoItem\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"A record is one node in a To-Do item tree (every record can contain nested sub-records).\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"status\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"User-selected state for this item (e.g. whether or not it is marked as done)\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"enum\\\\\\",\\\\\\"name\\\\\\":\\\\\\"ToDoStatus\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"* \`HIDDEN\`: not currently visible, e.g. because it becomes actionable in future\\\\\\\\n* \`ACTIONABLE\`: appears in the current to-do list\\\\\\\\n* \`DONE\`: marked as done, but still appears in the list\\\\\\\\n* \`ARCHIVED\`: marked as done and no longer visible\\\\\\\\n* \`DELETED\`: not done and removed from list (preserved for undo purposes)\\\\\\",\\\\\\"symbols\\\\\\":[\\\\\\"HIDDEN\\\\\\",\\\\\\"ACTIONABLE\\\\\\",\\\\\\"DONE\\\\\\",\\\\\\"ARCHIVED\\\\\\",\\\\\\"DELETED\\\\\\"]}},{\\\\\\"name\\\\\\":\\\\\\"title\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"One-line summary of the item\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"name\\\\\\":\\\\\\"description\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Detailed description (may contain HTML markup)\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"string\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"snoozeDate\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"Timestamp (milliseconds since epoch) at which the item should go from \`HIDDEN\` to \`ACTIONABLE\` status\\\\\\",\\\\\\"type\\\\\\":[\\\\\\"null\\\\\\",\\\\\\"long\\\\\\"]},{\\\\\\"name\\\\\\":\\\\\\"subItems\\\\\\",\\\\\\"doc\\\\\\":\\\\\\"List of children of this to-do tree node\\\\\\",\\\\\\"type\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"array\\\\\\",\\\\\\"items\\\\\\":\\\\\\"ToDoItem\\\\\\"}}]}}}]}\\",
+    UserName: \\"com.example.avro.User\\"
+};
+
+export namespace ComExampleAvro {
+    /**
+     * Stores details about an email address that a user has associated with their account.
+     */
+    export interface EmailAddress {
+        /**
+         * The email address, e.g. \`foo@example.com\`
+         */
+        address: string;
+        /**
+         * true if the user has clicked the link in a confirmation email to this address.
+         *
+         * Default: false
+         */
+        verified: boolean;
+        /**
+         * Timestamp (milliseconds since epoch) when the email address was added to the account.
+         */
+        dateAdded: number;
+        /**
+         * Timestamp (milliseconds since epoch) when an email sent to this address last bounced. Reset to null when the address no longer bounces.
+         */
+        dateBounced: null | number;
+    }
+    /**
+     * * \`PENDING\`: the user has started authorizing, but not yet finished
+     * * \`ACTIVE\`: the token should work
+     * * \`DENIED\`: the user declined the authorization
+     * * \`EXPIRED\`: the token used to work, but now it doesn't
+     * * \`REVOKED\`: the user has explicitly revoked the token
+     */
+    export type OAuthStatus = \\"PENDING\\" | \\"ACTIVE\\" | \\"DENIED\\" | \\"EXPIRED\\" | \\"REVOKED\\";
+    /**
+     * Stores access credentials for one Twitter account, as granted to us by the user by OAuth.
+     */
+    export interface TwitterAccount {
+        /**
+         * Indicator of whether this authorization is currently active, or has been revoked
+         */
+        status: ComExampleAvro.OAuthStatus;
+        /**
+         * Twitter's numeric ID for this user
+         */
+        userId: number;
+        /**
+         * The twitter username for this account (can be changed by the user)
+         */
+        screenName: string;
+        /**
+         * The OAuth token for this Twitter account
+         */
+        oauthToken: string;
+        /**
+         * The OAuth secret, used for signing requests on behalf of this Twitter account. \`null\` whilst the OAuth flow is not yet complete.
+         */
+        oauthTokenSecret: null | string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user last authorized this Twitter account
+         */
+        dateAuthorized: number;
+    }
+    /**
+     * * \`HIDDEN\`: not currently visible, e.g. because it becomes actionable in future
+     * * \`ACTIONABLE\`: appears in the current to-do list
+     * * \`DONE\`: marked as done, but still appears in the list
+     * * \`ARCHIVED\`: marked as done and no longer visible
+     * * \`DELETED\`: not done and removed from list (preserved for undo purposes)
+     */
+    export type ToDoStatus = \\"HIDDEN\\" | \\"ACTIONABLE\\" | \\"DONE\\" | \\"ARCHIVED\\" | \\"DELETED\\";
+    /**
+     * A record is one node in a To-Do item tree (every record can contain nested sub-records).
+     */
+    export interface ToDoItem {
+        /**
+         * User-selected state for this item (e.g. whether or not it is marked as done)
+         */
+        status: ComExampleAvro.ToDoStatus;
+        /**
+         * One-line summary of the item
+         */
+        title: string;
+        /**
+         * Detailed description (may contain HTML markup)
+         */
+        description: null | string;
+        /**
+         * Timestamp (milliseconds since epoch) at which the item should go from \`HIDDEN\` to \`ACTIONABLE\` status
+         */
+        snoozeDate: null | number;
+        /**
+         * List of children of this to-do tree node
+         */
+        subItems: ComExampleAvro.ToDoItem[];
+    }
+    /**
+     * This is a user record in a fictitious to-do-list management app. It supports arbitrary grouping and nesting of items, and allows you to add items by email or by tweeting.
+     *
+     * Note this app doesn't actually exist. The schema is just a demo for [Avrodoc](https://github.com/ept/avrodoc)!
+     */
+    export interface User {
+        /**
+         * System-assigned numeric user ID. Cannot be changed by the user.
+         */
+        id: number;
+        /**
+         * The username chosen by the user. Can be changed by the user.
+         */
+        username: string;
+        /**
+         * The user's password, hashed using [scrypt](http://www.tarsnap.com/scrypt.html).
+         */
+        passwordHash: string;
+        /**
+         * Timestamp (milliseconds since epoch) when the user signed up
+         */
+        signupDate: number;
+        /**
+         * All email addresses on the user's account
+         */
+        emailAddresses: ComExampleAvro.EmailAddress[];
+        /**
+         * All Twitter accounts that the user has OAuthed
+         */
+        twitterAccounts: ComExampleAvro.TwitterAccount[];
+        /**
+         * The top-level items in the user's to-do list
+         */
+        toDoItems: ComExampleAvro.ToDoItem[];
+    }
+}
+"
+`;
+
 exports[`Avro ts test Should convert User.avsc successfully with default as optional 1`] = `
 "/* eslint-disable @typescript-eslint/no-namespace */
 
@@ -5250,6 +7091,24 @@ export type RecordValue = ComAcmeMyapp.RecordValue;
 export namespace ComAcmeMyapp {
     export const RecordValueSchema = \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"record-value\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.acme.myapp\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\";
     export const RecordValueName = \\"com.acme.myapp.record-value\\";
+    export interface RecordValue {
+        name: string;
+    }
+}
+"
+`;
+
+exports[`Avro ts test Should convert WeirdName.avsc successfully using experimental type only namespaces 1`] = `
+"/* eslint-disable @typescript-eslint/no-namespace */
+
+export type RecordValue = ComAcmeMyapp.RecordValue;
+
+export const ComAcmeMyapp = {
+    RecordValueSchema: \\"{\\\\\\"type\\\\\\":\\\\\\"record\\\\\\",\\\\\\"name\\\\\\":\\\\\\"record-value\\\\\\",\\\\\\"namespace\\\\\\":\\\\\\"com.acme.myapp\\\\\\",\\\\\\"fields\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]}\\",
+    RecordValueName: \\"com.acme.myapp.record-value\\"
+};
+
+export namespace ComAcmeMyapp {
     export interface RecordValue {
         name: string;
     }

--- a/packages/avro-ts/test/external-references.spec.ts
+++ b/packages/avro-ts/test/external-references.spec.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { toTypeScript } from '../src';
 import { toExternalContext } from '../src';
@@ -6,12 +6,18 @@ import { toExternalContext } from '../src';
 const avscFiles = readdirSync(join(__dirname, 'external-references')).filter((file) =>
   file.endsWith('.avsc'),
 );
+const experimentalDir = join(__dirname, '__generated__', 'experimental');
 
 describe('Avro ts test', () => {
   beforeAll(() => {
     readdirSync(join(__dirname, '__generated__'))
       .filter((file) => file.endsWith('.external.ts'))
       .forEach((file) => unlinkSync(join(__dirname, '__generated__', file)));
+
+    mkdirSync(experimentalDir, { recursive: true });
+    readdirSync(experimentalDir)
+      .filter((file) => file.endsWith('.external.ts'))
+      .forEach((file) => unlinkSync(join(experimentalDir, file)));
   });
 
   it('Should convert %s successfully', () => {
@@ -52,6 +58,29 @@ describe('Avro ts test', () => {
         { external, withTypescriptEnums: true },
       );
       writeFileSync(join(__dirname, '__generated__', file + '.external.ts'), ts);
+      expect(ts).toMatchSnapshot(file);
+    }
+  });
+
+  // experimentalTypeOnlyNamespaces cannot be combined with withTypescriptEnums, so this variant
+  // always runs in non-enum mode.
+  it('Should convert %s successfully using experimental type only namespaces', () => {
+    const external = avscFiles.reduce(
+      (acc, file) => ({
+        ...acc,
+        [`./${file}.external`]: toExternalContext(
+          JSON.parse(String(readFileSync(join(__dirname, 'external-references', file)))),
+        ),
+      }),
+      {},
+    );
+
+    for (const file of avscFiles) {
+      const ts = toTypeScript(
+        JSON.parse(String(readFileSync(join(__dirname, 'external-references', file)))),
+        { external, experimentalTypeOnlyNamespaces: true },
+      );
+      writeFileSync(join(experimentalDir, file + '.external.ts'), ts);
       expect(ts).toMatchSnapshot(file);
     }
   });

--- a/packages/avro-ts/test/integration-should-fail.ts
+++ b/packages/avro-ts/test/integration-should-fail.ts
@@ -11,6 +11,7 @@ const complexUnionLogicalTypes: Messages.AccountMigrationEvent = {
         eventId: '123',
         traceToken: '123',
         // createdAt type is Moment
+        // @ts-expect-error testing a fail case failing
         createdAt: '123',
       },
       enrollmentId: '123',
@@ -29,9 +30,11 @@ function isAccountMigrationCancelled(
 }
 
 if (isAccountMigrationCancelled(complexUnionLogicalTypes)) {
+  // @ts-expect-error testing a fail case failing
   // .wat does not exist
   complexUnionLogicalTypes.event[Messages.AccountMigrationCancelledEventName].wat; // should fail
   // Our type is AccountMigrationCancelled, not AccountMigrationScheduled
   // even though AccountMigrationScheduled has a `scheduledAt` property.
+  // @ts-expect-error testing a fail case failing
   complexUnionLogicalTypes.event[Messages.AccountMigrationScheduledEventName].scheduledAt; // should fail
 }

--- a/packages/avro-ts/test/integration.spec.ts
+++ b/packages/avro-ts/test/integration.spec.ts
@@ -1,15 +1,21 @@
 import { schema } from 'avsc';
-import { readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { toTypeScript } from '../src';
 
 const avscFiles = readdirSync(join(__dirname, 'avro'));
+const experimentalDir = join(__dirname, '__generated__', 'experimental');
 
 describe('Avro ts test', () => {
   beforeAll(() => {
     readdirSync(join(__dirname, '__generated__'))
       .filter((file) => file.endsWith('.ts'))
       .forEach((file) => unlinkSync(join(__dirname, '__generated__', file)));
+
+    mkdirSync(experimentalDir, { recursive: true });
+    readdirSync(experimentalDir)
+      .filter((file) => file.endsWith('.ts'))
+      .forEach((file) => unlinkSync(join(experimentalDir, file)));
   });
 
   it.each(avscFiles)('Should convert %s successfully', (file) => {
@@ -52,4 +58,23 @@ describe('Avro ts test', () => {
     writeFileSync(join(__dirname, '__generated__', file + '.ts'), ts);
     expect(ts).toMatchSnapshot();
   });
+
+  it.each(avscFiles)(
+    'Should convert %s successfully using experimental type only namespaces',
+    (file) => {
+      const avro: schema.RecordType = JSON.parse(
+        String(readFileSync(join(__dirname, 'avro', file))),
+      );
+      const ts = toTypeScript(avro, {
+        experimentalTypeOnlyNamespaces: true,
+        logicalTypes: {
+          'timestamp-millis': { module: 'moment', named: 'Moment' },
+          date: 'string',
+          decimal: { module: 'decimal.js', named: 'Decimal' },
+        },
+      });
+      writeFileSync(join(experimentalDir, file + '.ts'), ts);
+      expect(ts).toMatchSnapshot();
+    },
+  );
 });


### PR DESCRIPTION
A problem with the existing codegen is it uses namespaces, a precusor feature to esm module specific to typescript that gets compiled into a iife with an object export. This does not work with certain modern tooling such as node's strip types support which allows you to evaluate typescript modules provided you don't use any non-erasable typescript only features. Namespaces cannot be erased.

The purpose of namespaces in this codegen is to... well provide namespaces mirroring avro namespaces and avoiding name collisions across avro namespaces. The idiomatic way of fixing this in typescript today would be to create a seperate esm module per namespace, but that is a major change and would require a lot of refactoring.

Instead what I've done is is changed the codegen to be functionally identical by splitting the codegen into two parts. Firstly we keep namespaces but make them type only exports - meaning that they are erasable by node's strip types feature. Secondly all value constants get exported inside of an object literal of the same name as the namespace. This functionally works identically to the old codegen from the pov of the consumer, but with the one cavet that you cannot use typescript enums in this mode.

I've called the mode `experimental-type-only-namespaces` and defaulted it to false, but if we were to ever release a semver breaking change I would aruge this should be the new default.

The longer term path is probably still moving towards having a esm module per avro namespace.